### PR TITLE
refactor(EditAgent): 移除不必要的 onConfirmUpdateEventQuestions 属性

### DIFF
--- a/src/pages/EditAgent/AgentArrangeConfig/OpenRemarksEdit/index.tsx
+++ b/src/pages/EditAgent/AgentArrangeConfig/OpenRemarksEdit/index.tsx
@@ -22,7 +22,6 @@ const OpenRemarksEdit: React.FC<OpenRemarksEditProps> = ({
   agentConfigInfo,
   pageArgConfigs,
   onChangeAgent,
-  onConfirmUpdateEventQuestions,
 }) => {
   const { token } = theme.useToken();
   // 开场白内容
@@ -95,7 +94,7 @@ const OpenRemarksEdit: React.FC<OpenRemarksEditProps> = ({
   const handleConfirmUpdateQuestions = (newQuestions: GuidQuestionDto[]) => {
     setOpen(false);
     setGuidQuestionDtos(newQuestions);
-    onConfirmUpdateEventQuestions(newQuestions, 'guidQuestionDtos');
+    onChangeAgent(newQuestions, 'guidQuestionDtos');
   };
 
   return (

--- a/src/pages/EditAgent/AgentArrangeConfig/index.tsx
+++ b/src/pages/EditAgent/AgentArrangeConfig/index.tsx
@@ -70,7 +70,6 @@ const AgentArrangeConfig: React.FC<AgentArrangeConfigProps> = ({
   agentId,
   agentConfigInfo,
   onChangeAgent,
-  onConfirmUpdateEventQuestions,
   onInsertSystemPrompt,
 }) => {
   // 插件弹窗
@@ -768,7 +767,6 @@ ${
           agentConfigInfo={agentConfigInfo}
           pageArgConfigs={pageArgConfigs}
           onChangeAgent={onChangeAgent}
-          onConfirmUpdateEventQuestions={onConfirmUpdateEventQuestions}
         />
       ),
       classNames: {

--- a/src/pages/EditAgent/index.tsx
+++ b/src/pages/EditAgent/index.tsx
@@ -219,10 +219,6 @@ const EditAgent: React.FC = () => {
     }
 
     setAgentConfigInfo(_agentConfigInfo);
-    // @ts-ignore
-    // setMessageList(prev => prev.map(item =>
-    //   item.id === null ? {...item, text: _agentConfigInfo.openingChatMsg} : item
-    // ))
 
     // 预置问题, 并且没有消息时，更新建议预置问题列表
     if (attr === 'guidQuestionDtos' && !messageList?.length) {
@@ -549,7 +545,6 @@ const EditAgent: React.FC = () => {
               agentId={agentId}
               agentConfigInfo={agentConfigInfo}
               onChangeAgent={handleChangeAgent}
-              onConfirmUpdateEventQuestions={handleUpdateEventQuestions}
               onInsertSystemPrompt={handleInsertSystemPrompt}
             />
           </div>

--- a/src/types/interfaces/agentConfig.ts
+++ b/src/types/interfaces/agentConfig.ts
@@ -61,10 +61,6 @@ export interface AgentArrangeConfigProps {
     value: string | string[] | number | GuidQuestionDto[],
     attr: string,
   ) => void;
-  onConfirmUpdateEventQuestions: (
-    value: string | string[] | number | GuidQuestionDto[],
-    attr: string,
-  ) => void;
   // 插入系统提示词
   onInsertSystemPrompt?: (text: string) => void;
 }
@@ -252,10 +248,6 @@ export interface OpenRemarksEditProps {
   pageArgConfigs: PageArgConfig[];
   onChangeAgent: (
     value: string | string[] | GuidQuestionDto[],
-    attr: string,
-  ) => void;
-  onConfirmUpdateEventQuestions: (
-    value: string | string[] | number | GuidQuestionDto[],
     attr: string,
   ) => void;
 }


### PR DESCRIPTION
- 从 EditAgent、AgentArrangeConfig 和 OpenRemarksEdit 组件中移除了 onConfirmUpdateEventQuestions 属性，简化了组件接口。
- 更新了相关逻辑，确保在处理预置问题时使用 onChangeAgent 方法，提升了代码的可读性和维护性。