### PR TITLE
feat(TiptapVariableInput): 添加 Raw 节点和 HTML 标签保护功能

### DIFF
--- a/src/components/ChatView/promptView.tsx
+++ b/src/components/ChatView/promptView.tsx
@@ -50,7 +50,7 @@ const PromptView: React.FC<PromptViewProps> = ({
   codeLanguage = CodeLangEnum.Text,
   theme = 'light',
 }) => {
-  console.log('codeLanguage', getCodeLanguage(codeLanguage), messageInfo);
+  // console.log('codeLanguage', getCodeLanguage(codeLanguage), messageInfo);
 
   const addCodeType = useCallback(
     (text: string) => {

--- a/src/components/TiptapVariableInput/README.md
+++ b/src/components/TiptapVariableInput/README.md
@@ -8,6 +8,7 @@
 - ✅ **可编辑变量**：支持在变量节点内部进行字符级编辑
 - ✅ **@ Mentions**：支持 @ 符号触发用户/文件等提及功能
 - ✅ **工具块**：支持 `{#ToolBlock ...#}` 格式的工具块插入
+- ✅ **Raw 节点**：支持展示 HTML/XML 原始内容，防止被 ProseMirror 解析
 - ✅ **Markdown 高亮**：支持 Markdown 语法高亮显示
 - ✅ **自动补全大括号**：智能补全 `{` 为 `{}`
 - ✅ **光标管理**：智能管理光标位置，避免跳字问题
@@ -249,6 +250,81 @@ useEffect(() => {
 }, [editor]);
 ```
 
+### 使用 Raw 节点展示 HTML/XML 原始内容
+
+Raw 节点用于展示 HTML 或 XML 的原始内容，防止被 ProseMirror 解析。适用于需要展示代码、配置或文档结构等场景。
+
+#### 通过编辑器 API 插入 Raw 节点
+
+```tsx
+import { RawNode } from '@/components/TiptapVariableInput';
+
+// 获取编辑器实例
+const [editor, setEditor] = useState<Editor | null>(null);
+
+<TiptapVariableInput value={value} onChange={setValue} getEditor={setEditor} />;
+
+// 插入 Raw 节点
+useEffect(() => {
+  if (editor) {
+    const htmlContent = '<div><p>Hello World</p></div>';
+    editor.commands.insertContent({
+      type: 'raw',
+      attrs: {
+        content: htmlContent,
+        type: 'html', // 或 'xml'
+      },
+    });
+  }
+}, [editor]);
+```
+
+#### 通过 HTML 格式使用 Raw 节点
+
+```tsx
+import { convertToRawNodeHTML } from '@/components/TiptapVariableInput/utils/htmlUtils';
+
+// 将 HTML/XML 内容转换为 Raw 节点的 HTML 格式
+const htmlContent = '<div><p>Hello World</p></div>';
+const rawNodeHTML = convertToRawNodeHTML(htmlContent, 'html');
+// 输出: <pre data-raw="true" data-content="&lt;div&gt;&lt;p&gt;Hello World&lt;/p&gt;&lt;/div&gt;" data-type="html" class="raw-content">...</pre>
+
+// 直接使用转换后的 HTML
+const value = `<p>普通文本</p>${rawNodeHTML}<p>更多文本</p>`;
+<TiptapVariableInput value={value} onChange={setValue} />;
+```
+
+#### 检测内容是否应该使用 Raw 节点
+
+```tsx
+import { shouldUseRawNode } from '@/components/TiptapVariableInput/utils/htmlUtils';
+
+const content = '<html><body><p>完整文档</p></body></html>';
+if (shouldUseRawNode(content)) {
+  // 使用 Raw 节点展示
+  const rawHTML = convertToRawNodeHTML(content, 'html');
+}
+```
+
+#### 从 HTML 中提取 Raw 节点内容
+
+```tsx
+import { extractRawNodeContents } from '@/components/TiptapVariableInput/utils/htmlUtils';
+
+const html =
+  '<p>文本</p><pre data-raw="true" data-content="&lt;div&gt;内容&lt;/div&gt;"></pre>';
+const rawContents = extractRawNodeContents(html);
+// 输出: ['<div>内容</div>']
+```
+
+#### Raw 节点特性
+
+- **原子节点**：Raw 节点是原子节点（`atom: true`），光标无法进入内部
+- **原始展示**：内容以纯文本形式展示，不会被 ProseMirror 解析
+- **样式支持**：使用代码字体和背景色，便于区分
+- **类型标识**：支持 `html` 和 `xml` 两种类型标识
+- **自动转义**：内容中的特殊字符会自动转义，确保正确显示
+
 ## 变量模式说明
 
 ### text 模式（默认）
@@ -321,6 +397,7 @@ const text = extractTextFromHTML(html);
 - `.variable-text-decoration`：文本模式变量装饰
 - `.tool-block-chip`：工具块节点
 - `.mention-node`：Mention 节点
+- `.raw-content`：Raw 节点（HTML/XML 原始内容）
 
 ## 目录结构
 
@@ -335,6 +412,7 @@ TiptapVariableInput/
 │   ├── MarkdownHighlight.ts       # Markdown 语法高亮
 │   ├── MentionNode.ts             # Mention 节点
 │   ├── MentionSuggestion.tsx      # Mention 建议
+│   ├── RawNode.ts                 # Raw 节点（HTML/XML 原始内容）
 │   ├── ToolBlockNode.ts            # 工具块节点
 │   ├── VariableCursorPlaceholder.ts # 变量光标占位符
 │   ├── VariableNode.ts            # 变量节点
@@ -389,6 +467,11 @@ A: 通过相应的 props 控制：
 - `enableEditableVariables={false}`：禁用可编辑变量
 
 ## 更新日志
+
+### v1.1.0
+
+- 新增 Raw 节点支持，用于展示 HTML/XML 原始内容
+- 添加 Raw 节点相关工具函数
 
 ### v1.0.0
 

--- a/src/components/TiptapVariableInput/TiptapVariableInput.tsx
+++ b/src/components/TiptapVariableInput/TiptapVariableInput.tsx
@@ -11,10 +11,11 @@ import { theme } from 'antd';
 import { isEqual } from 'lodash';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { AutoCompleteBraces } from './extensions/AutoCompleteBraces';
-import { CustomHTMLTagProtection } from './extensions/CustomHTMLTagProtection';
+import { HTMLTagProtection } from './extensions/HTMLTagProtection';
 import { MarkdownHighlight } from './extensions/MarkdownHighlight';
 import { MentionNode } from './extensions/MentionNode';
 import { MentionSuggestion } from './extensions/MentionSuggestion';
+import { RawNode } from './extensions/RawNode';
 import { ToolBlockNode } from './extensions/ToolBlockNode';
 import { VariableCursorPlaceholder } from './extensions/VariableCursorPlaceholder';
 import { VariableNode } from './extensions/VariableNode';
@@ -134,12 +135,14 @@ const TiptapVariableInputInner: React.FC<TiptapVariableInputProps> = ({
       extensions: [
         StarterKit,
         !disableMentions ? MentionNode : undefined,
+        RawNode, // Raw 节点扩展，用于展示 HTML/XML 原始内容
         // 总是包含两种变量类型：Node 用于不可编辑
+        // CustomHTMLTagProtection, // 自定义 XML 标签保护扩展，自动转义自定义 XML 标签（如 <OutputFormat>）
+        HTMLTagProtection, // HTML 标签保护扩展，自动转义不被 StarterKit 支持的 HTML 标签（如 <a>、<div> 等）
         VariableNode,
         VariableTextDecoration, // 方案C：纯文本装饰
         ToolBlockNode,
         MarkdownHighlight, // 添加 Markdown 语法高亮扩展
-        CustomHTMLTagProtection, // 自定义 XML 标签保护扩展，自动转义自定义 XML 标签（如 <OutputFormat>）
         // VariableCursorPlaceholder 应该在 VariableSuggestion 之前，确保光标可以在变量节点前后停留
         VariableCursorPlaceholder,
         // VariableSuggestion 应该在 AutoCompleteBraces 之前，这样它能够检测到 { 字符

--- a/src/components/TiptapVariableInput/extensions/HTMLTagProtection.ts
+++ b/src/components/TiptapVariableInput/extensions/HTMLTagProtection.ts
@@ -1,0 +1,99 @@
+/*
+ * HTML Tag Protection Extension
+ * HTML 标签保护扩展
+ *
+ * 功能：自动转义不被 Tiptap StarterKit 支持的 HTML 标签
+ * 防止这些标签被 Tiptap 解析时被移除，确保原始标签能够正确显示
+ */
+
+import { Extension } from '@tiptap/core';
+import { escapeHTML } from '../utils/htmlUtils';
+
+/**
+ * StarterKit 支持的 HTML 标签列表
+ * 这些标签不会被转义，会被 Tiptap 正常解析
+ */
+const SUPPORTED_HTML_TAGS = [
+  'p',
+  'br',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  's',
+  'strike',
+  'code',
+  'pre',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'hr',
+  'hardBreak',
+];
+
+/**
+ * 转义不被支持的 HTML 标签
+ * @param html HTML 内容
+ * @returns 转义后的 HTML 内容
+ */
+function escapeUnsupportedHTMLTags(html: string): string {
+  if (!html) return html;
+
+  // 匹配所有 HTML 标签
+  const tagRegex = /<\/?([a-zA-Z][a-zA-Z0-9]*)(?:\s+[^>]*)?>/g;
+
+  return html.replace(tagRegex, (match, tagName) => {
+    const lowerTagName = tagName.toLowerCase();
+
+    // 如果标签被支持，不转义
+    if (SUPPORTED_HTML_TAGS.includes(lowerTagName)) {
+      return match;
+    }
+
+    // 转义不被支持的标签
+    return escapeHTML(match);
+  });
+}
+
+/**
+ * HTML Tag Protection 扩展
+ * 在用户输入或粘贴时自动转义不被支持的 HTML 标签
+ */
+export const HTMLTagProtection = Extension.create({
+  name: 'htmlTagProtection',
+
+  /**
+   * 转换粘贴的 HTML 内容
+   * 在 Tiptap 解析粘贴的 HTML 之前，转义不被支持的 HTML 标签
+   */
+  transformPastedHTML(html: string) {
+    if (!html) return html;
+
+    // 检测并转义不被支持的 HTML 标签
+    return escapeUnsupportedHTMLTags(html);
+  },
+
+  /**
+   * 转换粘贴的纯文本
+   * 如果文本中包含 HTML 标签，转义不被支持的标签
+   */
+  transformPastedText(text: string) {
+    if (!text) return text;
+
+    // 检查是否包含 HTML 标签
+    if (!/<[^>]+>/.test(text)) {
+      return text; // 没有 HTML 标签，返回原始文本
+    }
+
+    // 转义不被支持的 HTML 标签
+    return escapeUnsupportedHTMLTags(text);
+  },
+});

--- a/src/components/TiptapVariableInput/extensions/RawNode.ts
+++ b/src/components/TiptapVariableInput/extensions/RawNode.ts
@@ -1,0 +1,151 @@
+/*
+ * Raw Node Extension
+ * 原始内容节点扩展，用于展示 HTML 或 XML 原始内容，不让 ProseMirror 解析
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * Raw 节点扩展
+ * 用于展示 HTML 或 XML 的原始内容，防止 ProseMirror 解析内部标签
+ * 使用 atom: true 确保节点作为原子单元，光标无法进入内部
+ */
+export const RawNode = Node.create({
+  name: 'raw',
+  group: 'block',
+  // 保留内部内容，不让 ProseMirror 解析
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      content: {
+        default: '',
+        parseHTML: (element) => {
+          // 从 data-content 属性或 textContent 获取内容
+          const rawContent =
+            element.getAttribute('data-content') || element.textContent || '';
+          // 如果内容被转义了，需要反转义
+          return rawContent
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'");
+        },
+        renderHTML: (attributes) => {
+          // 在 data-content 属性中也需要转义
+          const escapedContent = (attributes.content || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+          return {
+            'data-content': escapedContent,
+          };
+        },
+      },
+      // 可选：添加类型标识，用于区分 HTML 和 XML
+      type: {
+        default: 'html',
+        parseHTML: (element) => {
+          return element.getAttribute('data-type') || 'html';
+        },
+        renderHTML: (attributes) => {
+          return {
+            'data-type': attributes.type,
+          };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'pre[data-raw]',
+        getAttrs: (node) => {
+          if (typeof node === 'string') return false;
+          const element = node as HTMLElement;
+          return {
+            content:
+              element.getAttribute('data-content') || element.textContent || '',
+            type: element.getAttribute('data-type') || 'html',
+          };
+        },
+      },
+      {
+        tag: 'raw',
+        getAttrs: (node) => {
+          if (typeof node === 'string') return false;
+          const element = node as HTMLElement;
+          return {
+            content:
+              element.getAttribute('content') || element.textContent || '',
+            type: element.getAttribute('type') || 'html',
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { content, type } = HTMLAttributes;
+    // 转义内容中的特殊字符，确保在 HTML 中正确显示
+    const escapedContent = (content || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+
+    return [
+      'pre',
+      mergeAttributes(HTMLAttributes, {
+        'data-raw': 'true',
+        'data-content': escapedContent,
+        'data-type': type,
+        class: 'raw-content',
+        // 使用 white-space: pre-wrap 保持格式
+        style: 'white-space: pre-wrap; word-wrap: break-word;',
+      }),
+      escapedContent,
+    ];
+  },
+
+  /**
+   * 自定义节点视图，确保内容以纯文本形式显示
+   */
+  addNodeView() {
+    return ({ node }) => {
+      const pre = document.createElement('pre');
+      pre.className = 'raw-content';
+      pre.setAttribute('data-raw', 'true');
+      pre.setAttribute('data-content', node.attrs.content || '');
+      pre.setAttribute('data-type', node.attrs.type || 'html');
+      pre.style.whiteSpace = 'pre-wrap';
+      pre.style.wordWrap = 'break-word';
+      pre.textContent = node.attrs.content || '';
+      pre.contentEditable = 'false';
+
+      return {
+        dom: pre,
+        update: (updatedNode) => {
+          // 更新内容
+          if (pre.textContent !== (updatedNode.attrs.content || '')) {
+            pre.textContent = updatedNode.attrs.content || '';
+            pre.setAttribute('data-content', updatedNode.attrs.content || '');
+          }
+          // 更新类型
+          if (
+            pre.getAttribute('data-type') !== (updatedNode.attrs.type || 'html')
+          ) {
+            pre.setAttribute('data-type', updatedNode.attrs.type || 'html');
+          }
+          return true;
+        },
+      };
+    };
+  },
+});

--- a/src/components/TiptapVariableInput/index.ts
+++ b/src/components/TiptapVariableInput/index.ts
@@ -11,8 +11,10 @@ export type {
 } from './types';
 
 // 导出扩展（供高级用户使用）
+export { HTMLTagProtection } from './extensions/HTMLTagProtection';
 export { MentionNode } from './extensions/MentionNode';
 export { MentionSuggestion } from './extensions/MentionSuggestion';
+export { RawNode } from './extensions/RawNode';
 export { ToolBlockNode } from './extensions/ToolBlockNode';
 export { VariableNode } from './extensions/VariableNode';
 export { VariableSuggestion } from './extensions/VariableSuggestion';

--- a/src/components/TiptapVariableInput/styles.less
+++ b/src/components/TiptapVariableInput/styles.less
@@ -356,3 +356,28 @@
   color: @colorTextTertiary;
   flex-shrink: 0;
 }
+
+// Raw 节点样式（用于展示 HTML/XML 原始内容）
+.raw-content {
+  display: block;
+  background-color: @colorFillTertiary;
+  border: 1px solid @colorBorderSecondary;
+  border-radius: @borderRadiusSm;
+  padding: @paddingSm @padding;
+  margin: @marginSm 0;
+  font-family: @fontFamilyCode;
+  font-size: @fontSizeSm;
+  line-height: @lineHeight;
+  color: @colorText;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-x: auto;
+  user-select: text; // 允许选择文本
+  cursor: text;
+
+  // 选中状态样式
+  &:focus {
+    outline: 1px solid @colorPrimary;
+    outline-offset: -1px;
+  }
+}


### PR DESCRIPTION
- 新增 RawNode 扩展，用于展示 HTML/XML 原始内容，防止被 ProseMirror 解析
- 新增 HTMLTagProtection 扩展，自动转义不被 StarterKit 支持的 HTML 标签
- 添加 Raw 节点相关工具函数（shouldUseRawNode, convertToRawNodeHTML, extractRawNodeContents）
- 更新 extractTextFromHTML 以支持 Raw 节点内容提取
- 添加 Raw 节点样式和文档说明