### PR TITLE
Feat pujing

### DIFF
--- a/src/models/conversationInfo.ts
+++ b/src/models/conversationInfo.ts
@@ -277,7 +277,7 @@ export default () => {
         // 查询文件列表
         await runGetStaticFileList(cId);
       },
-      3000,
+      5000,
       { leading: true, trailing: true },
     ),
     [runGetStaticFileList],

--- a/src/pages/Chat/DropdownChangeName/index.tsx
+++ b/src/pages/Chat/DropdownChangeName/index.tsx
@@ -26,8 +26,13 @@ import styles from './index.less';
 const cx = classNames.bind(styles);
 
 interface Porps {
+  agentId: number;
+  /** 会话信息 */
   conversationInfo: ConversationInfo;
+  /** 设置会话信息 */
   setConversationInfo: (value: ConversationInfo) => void;
+  /** 是否是开放应用智能体会话 */
+  isAppSidebarMode?: boolean;
 }
 
 type FieldType = {
@@ -35,8 +40,10 @@ type FieldType = {
 };
 
 const DropdownChangeName: React.FC<Porps> = ({
+  agentId,
   conversationInfo,
   setConversationInfo,
+  isAppSidebarMode = false,
 }) => {
   const navigate = useNavigate();
   const { runHistory, runHistoryItem } = useModel('conversationHistory');
@@ -89,16 +96,22 @@ const DropdownChangeName: React.FC<Porps> = ({
         });
         message.success('修改成功');
 
+        const _agentId = isAppSidebarMode ? agentId : null;
+
         // 更新所有智能体的历史记录
         runHistory({
-          agentId: null,
+          agentId: _agentId,
           limit: 20,
         });
-        // 更新当前智能体的历史记录
-        runHistoryItem({
-          agentId: result?.data?.agentId,
-          limit: 20,
-        });
+
+        // 如果不是应用智能体模式，更新当前智能体的历史记录(用于右侧智能体详情侧边栏中的历史会话列表)
+        if (!isAppSidebarMode) {
+          // 更新当前智能体的历史记录
+          runHistoryItem({
+            agentId: result?.data?.agentId,
+            limit: 20,
+          });
+        }
       }
     },
   });

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -532,7 +532,7 @@ const Chat: React.FC = () => {
 
   useEffect(() => {
     // 应用智能体模式下，不获取当前智能体的历史记录
-    if (isAppSidebarMode) {
+    if (location.pathname?.includes('/app/chat/')) {
       return;
     }
     // 获取当前智能体的历史记录
@@ -540,7 +540,7 @@ const Chat: React.FC = () => {
       agentId,
       limit: 20,
     });
-  }, [id, agentId, isAppSidebarMode]);
+  }, [id, agentId, location.pathname]);
 
   useEffect(() => {
     addBaseTarget();
@@ -1070,10 +1070,10 @@ const Chat: React.FC = () => {
         <header className={cx(styles['title-box'])}>
           <div className={cx(styles['title-container'])}>
             <DropdownChangeName
+              agentId={agentId}
               conversationInfo={conversationInfo}
-              setConversationInfo={(value) => {
-                setConversationInfo(value);
-              }}
+              setConversationInfo={setConversationInfo}
+              isAppSidebarMode={isAppSidebarMode}
             />
             <div className={cx('flex', 'items-center', 'gap-4')}>
               {/* 应用智能体模式下，显示内容导航按钮 */}

--- a/src/pages/OpenApp/BaseTemplate/index.tsx
+++ b/src/pages/OpenApp/BaseTemplate/index.tsx
@@ -10,10 +10,8 @@ import User from '@/layouts/DynamicMenusLayout/User';
 import Setting from '@/layouts/Setting';
 import { ConversationInfo } from '@/types/interfaces/conversationInfo';
 import {
-  ClockCircleOutlined,
   EllipsisOutlined,
   LoadingOutlined,
-  PlusCircleOutlined,
   RightOutlined,
 } from '@ant-design/icons';
 import classNames from 'classnames';
@@ -249,7 +247,7 @@ const BaseTemplate: React.FC = () => {
           onClick={() => createAppNewConversation(agentId)}
         >
           <span className={styles.newSessionText}>
-            <PlusCircleOutlined />
+            <SvgIcon name="icons-nav-new_chat" style={{ fontSize: 16 }} />
             新建会话
           </span>
           <div className={cx('flex', 'items-center', 'gap-4')}>
@@ -279,10 +277,7 @@ const BaseTemplate: React.FC = () => {
           ) : (
             <>
               <div className={cx(styles['history-title'])}>
-                <span className={cx(styles.title)}>
-                  <ClockCircleOutlined />
-                  历史会话
-                </span>
+                <span className={cx(styles.title)}>历史会话</span>
 
                 <ConditionRender condition={conversationList?.length}>
                   <span

--- a/src/pages/SystemManagement/Content/Agent/index.tsx
+++ b/src/pages/SystemManagement/Content/Agent/index.tsx
@@ -225,13 +225,19 @@ const Agent: React.FC = () => {
         [AccessControlEnum.Filter]: { text: '开启', status: 'Processing' },
       },
       valueType: 'select',
-      render: (_, record: SystemAgentInfo) => (
-        <Switch
-          checked={record.accessControl === AccessControlEnum.Filter}
-          loading={accessControlLoadingMap[record.id] || false}
-          onChange={(checked) => handleAccessControlChange(record, checked)}
-        />
-      ),
+      render: (_, record: SystemAgentInfo) => {
+        const accessControlSwitchEnabled =
+          record.publishStatus === PublishStatusEnum.Published &&
+          record.publishScope === PluginPublishScopeEnum.Tenant;
+        return (
+          <Switch
+            checked={record.accessControl === AccessControlEnum.Filter}
+            disabled={!accessControlSwitchEnabled}
+            loading={accessControlLoadingMap[record.id] || false}
+            onChange={(checked) => handleAccessControlChange(record, checked)}
+          />
+        );
+      },
     },
     {
       title: '操作',

--- a/src/pages/SystemManagement/Content/KnowledgeBase/index.tsx
+++ b/src/pages/SystemManagement/Content/KnowledgeBase/index.tsx
@@ -6,17 +6,19 @@ import type { ActionItem } from '@/components/ProComponents/TableActions';
 import WorkspaceLayout from '@/components/WorkspaceLayout';
 import { SUCCESS_CODE } from '@/constants/codes.constants';
 import {
+  apiSystemResourceKnowledgeAccessControl,
   apiSystemResourceKnowledgeDelete,
   apiSystemResourceKnowledgeList,
 } from '@/services/systemManage';
+import { AccessControlEnum } from '@/types/enums/systemManage';
 import { SystemKnowledgeInfo } from '@/types/interfaces/systemManage';
 import {
   ActionType,
   FormInstance,
   ProColumns,
 } from '@ant-design/pro-components';
-import { message } from 'antd';
-import { useCallback, useEffect, useRef } from 'react';
+import { message, Switch } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useModel } from 'umi';
 
 const KnowledgeBase: React.FC = () => {
@@ -24,6 +26,9 @@ const KnowledgeBase: React.FC = () => {
   const actionRef = useRef<ActionType>();
   const formRef = useRef<FormInstance>();
   const location = useLocation();
+  const [accessControlLoadingMap, setAccessControlLoadingMap] = useState<
+    Record<number, boolean>
+  >({});
 
   const handleReset = useCallback(() => {
     // 重置表单
@@ -63,6 +68,28 @@ const KnowledgeBase: React.FC = () => {
       message.error(response.message || '删除失败');
     }
   }, []);
+
+  /**
+   * 切换管控状态
+   */
+  const handleAccessControlChange = useCallback(
+    async (record: SystemKnowledgeInfo, checked: boolean) => {
+      const newStatus = checked ? 1 : 0;
+      setAccessControlLoadingMap((prev) => ({ ...prev, [record.id]: true }));
+      try {
+        const response = await apiSystemResourceKnowledgeAccessControl(
+          record.id,
+          newStatus,
+        );
+        if (response.code === SUCCESS_CODE) {
+          actionRef.current?.reload();
+        }
+      } finally {
+        setAccessControlLoadingMap((prev) => ({ ...prev, [record.id]: false }));
+      }
+    },
+    [],
+  );
 
   /**
    * 操作列配置
@@ -130,6 +157,26 @@ const KnowledgeBase: React.FC = () => {
       valueType: 'dateTime',
     },
     {
+      title: '管控',
+      tooltip: '若开启管控，需授权才能使用该知识库',
+      dataIndex: 'accessControl',
+      align: 'center',
+      width: 100,
+      fixed: 'right',
+      valueEnum: {
+        [AccessControlEnum.NoFilter]: { text: '关闭', status: 'Default' },
+        [AccessControlEnum.Filter]: { text: '开启', status: 'Processing' },
+      },
+      valueType: 'select',
+      render: (_, record: SystemKnowledgeInfo) => (
+        <Switch
+          checked={record.accessControl === AccessControlEnum.Filter}
+          loading={accessControlLoadingMap[record.id] || false}
+          onChange={(checked) => handleAccessControlChange(record, checked)}
+        />
+      ),
+    },
+    {
       title: '操作',
       valueType: 'option',
       fixed: 'right',
@@ -152,12 +199,14 @@ const KnowledgeBase: React.FC = () => {
     current?: number;
     name?: string;
     creatorName?: string;
+    accessControl?: AccessControlEnum;
   }) => {
     const response = await apiSystemResourceKnowledgeList({
       pageNo: params.current || 1,
       pageSize: params.pageSize || 15,
       name: params.name,
       creatorName: params.creatorName,
+      accessControl: params.accessControl,
     });
 
     return {

--- a/src/pages/SystemManagement/Content/KnowledgeBase/index.tsx
+++ b/src/pages/SystemManagement/Content/KnowledgeBase/index.tsx
@@ -20,6 +20,7 @@ import {
 import { message, Switch } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useModel } from 'umi';
+import TargetAuthModal from '../components/TargetAuthModal';
 
 const KnowledgeBase: React.FC = () => {
   const { hasPermission } = useModel('menuModel');
@@ -29,6 +30,11 @@ const KnowledgeBase: React.FC = () => {
   const [accessControlLoadingMap, setAccessControlLoadingMap] = useState<
     Record<number, boolean>
   >({});
+
+  // 授权弹窗相关状态
+  const [authModalOpen, setAuthModalOpen] = useState<boolean>(false);
+  const [currentKnowledgeInfo, setCurrentKnowledgeInfo] =
+    useState<SystemKnowledgeInfo | null>(null);
 
   const handleReset = useCallback(() => {
     // 重置表单
@@ -92,6 +98,14 @@ const KnowledgeBase: React.FC = () => {
   );
 
   /**
+   * 处理授权
+   */
+  const handleAuth = useCallback((record: SystemKnowledgeInfo) => {
+    setCurrentKnowledgeInfo(record);
+    setAuthModalOpen(true);
+  }, []);
+
+  /**
    * 操作列配置
    */
   const getActions = useCallback(
@@ -101,6 +115,12 @@ const KnowledgeBase: React.FC = () => {
         label: '查看',
         disabled: !hasPermission('content_knowledge_query_detail'),
         onClick: handleView,
+      },
+      {
+        key: 'auth',
+        label: '授权',
+        visible: record.accessControl === AccessControlEnum.Filter,
+        onClick: handleAuth,
       },
       {
         key: 'delete',
@@ -226,6 +246,18 @@ const KnowledgeBase: React.FC = () => {
         request={request}
         onReset={handleReset}
         showQueryButtons={hasPermission('content_knowledge_query_list')}
+      />
+
+      {/* 授权弹窗 */}
+      <TargetAuthModal
+        open={authModalOpen}
+        targetId={currentKnowledgeInfo?.id || 0}
+        targetName={currentKnowledgeInfo?.name}
+        targetType="knowledge"
+        onCancel={() => {
+          setAuthModalOpen(false);
+          setCurrentKnowledgeInfo(null);
+        }}
       />
     </WorkspaceLayout>
   );

--- a/src/pages/SystemManagement/Content/WebApplication/index.tsx
+++ b/src/pages/SystemManagement/Content/WebApplication/index.tsx
@@ -227,13 +227,19 @@ const WebApplication: React.FC = () => {
         [AccessControlEnum.Filter]: { text: '开启', status: 'Processing' },
       },
       valueType: 'select',
-      render: (_, record: SystemWebappInfo) => (
-        <Switch
-          checked={record.accessControl === AccessControlEnum.Filter}
-          loading={accessControlLoadingMap[record.agentId] || false}
-          onChange={(checked) => handleAccessControlChange(record, checked)}
-        />
-      ),
+      render: (_, record: SystemWebappInfo) => {
+        const accessControlSwitchEnabled =
+          record.publishStatus === PublishStatusEnum.Published &&
+          record.publishScope === PluginPublishScopeEnum.Tenant;
+        return (
+          <Switch
+            checked={record.accessControl === AccessControlEnum.Filter}
+            disabled={!accessControlSwitchEnabled}
+            loading={accessControlLoadingMap[record.agentId] || false}
+            onChange={(checked) => handleAccessControlChange(record, checked)}
+          />
+        );
+      },
     },
     {
       title: '操作',

--- a/src/pages/SystemManagement/Content/components/TargetAuthModal/index.tsx
+++ b/src/pages/SystemManagement/Content/components/TargetAuthModal/index.tsx
@@ -11,6 +11,8 @@ import {
   AccessibleUserGroupInfo,
   apiAgentBindRestrictionTargets,
   apiAgentRestrictionTargets,
+  apiKnowledgeBindRestrictionTargets,
+  apiKnowledgeRestrictionTargets,
   apiModelBindRestrictionTargets,
   apiModelRestrictionTargets,
   apiPageAgentBindRestrictionTargets,
@@ -28,7 +30,7 @@ interface TargetAuthModalProps {
   /** 目标名称 */
   targetName?: string;
   /** 目标类型 */
-  targetType: 'agent' | 'page' | 'model';
+  targetType: 'agent' | 'page' | 'model' | 'knowledge';
   /** 取消回调 */
   onCancel: () => void;
 }
@@ -65,6 +67,8 @@ const TargetAuthModal: React.FC<TargetAuthModalProps> = ({
       ? apiAgentRestrictionTargets
       : targetType === 'page'
       ? apiPageAgentRestrictionTargets
+      : targetType === 'knowledge'
+      ? apiKnowledgeRestrictionTargets
       : apiModelRestrictionTargets;
 
   // 绑定限制访问对象接口
@@ -73,6 +77,8 @@ const TargetAuthModal: React.FC<TargetAuthModalProps> = ({
       ? apiAgentBindRestrictionTargets
       : targetType === 'page'
       ? apiPageAgentBindRestrictionTargets
+      : targetType === 'knowledge'
+      ? apiKnowledgeBindRestrictionTargets
       : apiModelBindRestrictionTargets;
 
   // 查询完整的角色列表

--- a/src/pages/SystemManagement/Content/content-manage.ts
+++ b/src/pages/SystemManagement/Content/content-manage.ts
@@ -59,8 +59,6 @@ export interface AccessibleUserGroupInfo {
   source: UserGroupSourceEnum;
   /** 状态,1:启用 0:禁用 */
   status: UserGroupStatusEnum;
-  /** 最大用户数，0表示不限制 */
-  maxUserCount: number;
   /** 排序 */
   sortIndex: number;
   /** 租户ID */

--- a/src/pages/SystemManagement/Content/content-manage.ts
+++ b/src/pages/SystemManagement/Content/content-manage.ts
@@ -89,7 +89,7 @@ export interface RestrictionTargets {
 
 /** 绑定智能体限制访问对象参数 */
 export interface BindRestrictionTargetsParams {
-  // 主体ID（如模型ID、智能体ID、网页应用ID）
+  // 主体ID（如模型ID、智能体ID、网页应用ID、知识库ID）
   subjectId: number;
   // 可访问的角色ID列表
   roleIds: number[];
@@ -164,5 +164,29 @@ export async function apiSystemResourceAgentAccess(
 ): Promise<RequestResponse<null>> {
   return request(`/api/system/resource/agent/access/${id}/${status}`, {
     method: 'POST',
+  });
+}
+
+// ============================= 内容管理-知识库 =============================
+
+// 查询知识库限制访问的对象
+export async function apiKnowledgeRestrictionTargets(
+  knowledgeId: number,
+): Promise<RequestResponse<RestrictionTargets>> {
+  return request(
+    `/api/system/resource/knowledge/restriction-targets/${knowledgeId}`,
+    {
+      method: 'GET',
+    },
+  );
+}
+
+// 绑定知识库限制访问对象（全量覆盖）
+export async function apiKnowledgeBindRestrictionTargets(
+  data: BindRestrictionTargetsParams,
+): Promise<RequestResponse<RestrictionTargets>> {
+  return request('/api/system/resource/knowledge/bind-restriction-targets', {
+    method: 'POST',
+    data,
   });
 }

--- a/src/pages/SystemManagement/MenuPermission/UserGroupManage/components/UserGroupFormModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/UserGroupManage/components/UserGroupFormModal/index.tsx
@@ -97,7 +97,6 @@ const UserGroupFormModal: React.FC<UserGroupFormModalProps> = ({
       form.setFieldsValue({
         name: data.name,
         description: data.description,
-        maxUserCount: data.maxUserCount,
         sortIndex: data.sortIndex || 1,
         status: data.status === UserGroupStatusEnum.Enabled,
         source: data.source || UserGroupSourceEnum.UserDefined,
@@ -120,7 +119,6 @@ const UserGroupFormModal: React.FC<UserGroupFormModalProps> = ({
           source: UserGroupSourceEnum.UserDefined,
           sortIndex: defaultSortIndex || 1,
           status: true,
-          maxUserCount: 100,
         });
       }
     }
@@ -180,25 +178,6 @@ const UserGroupFormModal: React.FC<UserGroupFormModalProps> = ({
               rules={[{ required: true, message: '请输入用户组名称' }]}
             >
               <Input placeholder="请输入用户组名称" maxLength={50} showCount />
-            </Form.Item>
-          </Col>
-
-          <Col span={12}>
-            <Form.Item
-              label="最大用户数"
-              name="maxUserCount"
-              rules={[{ required: true, message: '请输入最大用户数' }]}
-              tooltip={{
-                title: '最大值为2147483647',
-                icon: <InfoCircleOutlined />,
-              }}
-            >
-              <InputNumber
-                placeholder="请输入最大用户数"
-                className={cx('w-full')}
-                min={1}
-                max={2147483647}
-              />
             </Form.Item>
           </Col>
 

--- a/src/pages/SystemManagement/MenuPermission/UserGroupManage/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/UserGroupManage/index.tsx
@@ -191,7 +191,6 @@ const UserGroupManage: React.FC = () => {
     const params: UpdateUserGroupParams = {
       id: record.id,
       status: newStatus,
-      maxUserCount: record.maxUserCount,
     };
     try {
       setUpdateStatusLoadingMap((prev) => ({ ...prev, [record.id]: true }));

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.less
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.less
@@ -11,7 +11,7 @@
 .dataPermissionForm {
   // 抵消 Row gutter 的负边距
   margin: 0 -8px;
-  padding: 0 12px 0 8px;
+  padding: 0 @paddingSm 0 @paddingXs;
 }
 
 :global {
@@ -35,15 +35,36 @@
   .tabContent {
     flex: 1;
     overflow-y: hidden;
+    overflow-x: hidden;
     height: 100%;
+    min-width: 0;
 
     .searchInput {
-      padding-top: 16px;
+      padding-top: @padding;
+    }
+
+    // API 权限树：避免标题过长撑出横向滚动
+    :global {
+      .ant-tree-list-holder-inner .ant-tree-treenode {
+        align-items: center;
+      }
+
+      .ant-tree-node-content-wrapper {
+        overflow: hidden;
+        flex: 1;
+        min-width: 0;
+      }
+
+      .ant-tree-title {
+        width: 100%;
+        min-width: 0;
+        overflow: hidden;
+      }
     }
   }
 
   .leftList {
-    padding-right: 12px;
+    padding-right: @paddingSm;
   }
 
   .rightSeparator {
@@ -51,7 +72,7 @@
   }
 
   .rightList {
-    padding: 0 12px;
+    padding: 0 @paddingSm;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -64,5 +85,53 @@
     justify-content: center;
     flex: 1;
     color: rgba(0, 0, 0, 45%);
+  }
+}
+
+// API 权限树节点标题：左侧名称/path 省略，右侧控件占位不压缩
+.openApiTreeTitleRow {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  gap: 12px;
+  justify-content: space-between;
+  height: 26px;
+
+  .openApiTreeTitleLeft {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow: hidden;
+
+    .openApiTreeTitleName {
+      flex: 0 1 auto;
+      max-width: 60%;
+    }
+
+    .openApiTreeTitlePath {
+      flex: 1 1 auto;
+      min-width: 0;
+      font-size: 12px;
+      color: @colorTextSecondary;
+    }
+  }
+
+  .openApiTreeTitleControls {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    .font-12 {
+      font-size: @fontSizeSm;
+      color: @colorTextSecondary;
+    }
+
+    .input-number {
+      width: 72px;
+    }
   }
 }

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.less
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.less
@@ -114,7 +114,7 @@
     .openApiTreeTitlePath {
       flex: 1 1 auto;
       min-width: 0;
-      font-size: 12px;
+      font-size: @fontSizeSm;
       color: @colorTextSecondary;
     }
   }

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -6,20 +6,26 @@ import {
 } from '@/pages/SystemManagement/MenuPermission/services/role-manage';
 import {
   apiSystemResourceAgentListByIds,
+  apiSystemResourceKnowledgeListByIds,
   apiSystemResourcePageListByIds,
 } from '@/pages/UserManage/user-manage';
 import { apiPublishedAgentList } from '@/services/square';
-import { apiSystemModelList } from '@/services/systemManage';
+import {
+  apiSystemModelList,
+  apiSystemResourceKnowledgeList,
+} from '@/services/systemManage';
 import { AgentComponentTypeEnum } from '@/types/enums/agent';
 import { AccessControlEnum } from '@/types/enums/systemManage';
 import type { AgentConfigInfo } from '@/types/interfaces/agent';
 import type { CustomPageDto } from '@/types/interfaces/pageDev';
 import type { Page } from '@/types/interfaces/request';
+import type { SquarePublishedItemInfo } from '@/types/interfaces/square';
 import type {
-  SquarePublishedItemInfo,
-  SquarePublishedListParams,
-} from '@/types/interfaces/square';
-import type { ModelConfigDto } from '@/types/interfaces/systemManage';
+  KnowledgeInfoById,
+  ModelConfigDto,
+  SystemKnowledgeInfo,
+  SystemKnowledgePage,
+} from '@/types/interfaces/systemManage';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import {
   Col,
@@ -62,7 +68,9 @@ export type DataPermissionTabKey =
   | 'model'
   | 'agent'
   | 'page'
-  | 'dataPermission';
+  | 'knowledge'
+  | 'dataPermission'
+  | 'apiPermission';
 
 // 数据权限标签页配置（只包含标签名称）
 export const DATA_PERMISSION_TAB_ITEMS: TabsProps['items'] = [
@@ -106,8 +114,34 @@ export const DATA_PERMISSION_TAB_ITEMS: TabsProps['items'] = [
     ),
   },
   {
+    key: 'knowledge',
+    label: (
+      <span>
+        知识库
+        <Tooltip title="在内容管理中开启管控后可在此处进行授权，若开启管控，需授权才能使用该知识库">
+          <InfoCircleOutlined
+            style={{ marginLeft: 4, color: '#999', cursor: 'help' }}
+          />
+        </Tooltip>
+      </span>
+    ),
+  },
+  {
     key: 'dataPermission',
     label: '开发权限',
+  },
+  {
+    key: 'apiPermission',
+    label: (
+      <span>
+        API权限
+        <Tooltip title="需授权才能使用API">
+          <InfoCircleOutlined
+            style={{ marginLeft: 4, color: '#999', cursor: 'help' }}
+          />
+        </Tooltip>
+      </span>
+    ),
   },
 ];
 
@@ -157,9 +191,24 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   // 网页应用分页状态
   const [pagePage, setPagePage] = useState<number>(1);
   const [pageHasMore, setPageHasMore] = useState<boolean>(false);
+
+  // ======================================= 知识库 =======================================
+  // 知识库列表（管控开启的资源）
+  const [knowledgeList, setKnowledgeList] = useState<SystemKnowledgeInfo[]>([]);
+  const [selectedKnowledgeIds, setSelectedKnowledgeIds] = useState<number[]>(
+    [],
+  );
+  const [selectedKnowledgeList, setSelectedKnowledgeList] = useState<
+    KnowledgeInfoById[]
+  >([]);
+  const [knowledgeSearchKw, setKnowledgeSearchKw] = useState<string>('');
+  const [knowledgePage, setKnowledgePage] = useState<number>(1);
+  const [knowledgeHasMore, setKnowledgeHasMore] = useState<boolean>(false);
+
   // 滚动容器引用
   const agentListScrollRef = useRef<HTMLDivElement>(null);
   const pageListScrollRef = useRef<HTMLDivElement>(null);
+  const knowledgeListScrollRef = useRef<HTMLDivElement>(null);
   // 保存表单值的状态，用于在组件卸载时保留值
   const [formValuesCache, setFormValuesCache] = useState<DataPermission>({});
 
@@ -206,23 +255,14 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       // 同时更新缓存
       setFormValuesCache(formData as DataPermission);
 
-      // 存储查询到的 modelIds，用于后续处理
-      if (result.modelIds && result.modelIds.length > 0) {
-        // 直接设置选中状态
-        setSelectedModelIds(result.modelIds);
-      } else {
-        setSelectedModelIds([]);
-      }
-
+      // 直接设置选中状态
+      setSelectedModelIds(result?.modelIds || []);
       // 回显智能体选择
-      if (result.agentIds && result.agentIds.length > 0) {
-        setSelectedAgentIds(result.agentIds);
-      }
-
+      setSelectedAgentIds(result?.agentIds || []);
       // 回显应用页面选择
-      if (result.pageAgentIds && result.pageAgentIds.length > 0) {
-        setSelectedPageAgentIds(result.pageAgentIds);
-      }
+      setSelectedPageAgentIds(result?.pageAgentIds || []);
+      // 回显知识库选择
+      setSelectedKnowledgeIds(result?.knowledgeIds || []);
     },
   });
 
@@ -248,17 +288,66 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     },
   );
 
+  // ======================================= 知识库 =======================================
+  // 根据id列表查询知识库列表（数据权限回显）
+  const { run: runGetKnowledgeListByIds } = useRequest(
+    apiSystemResourceKnowledgeListByIds,
+    {
+      manual: true,
+      onSuccess: (result: KnowledgeInfoById[]) => {
+        setSelectedKnowledgeList(result || []);
+      },
+    },
+  );
+
+  // 查询知识库列表
+  const { loading: knowledgeLoading, run: runKnowledgeList } = useRequest(
+    apiSystemResourceKnowledgeList,
+    {
+      manual: true,
+      onSuccess: (result: SystemKnowledgePage) => {
+        // 知识库列表
+        const records = result?.records || [];
+        // 	总记录数
+        const total = result?.total ?? 0;
+        // 当前页码
+        const currentPage = result?.pageNo ?? 1;
+        // 每页条数
+        const pageSize = result?.pageSize ?? 20;
+
+        // 判断是否还有更多数据
+        setKnowledgeHasMore(currentPage * pageSize < total);
+        // 更新页码
+        setKnowledgePage(currentPage);
+
+        // 如果是第一页（搜索或首次加载），直接替换列表
+        if (currentPage === 1) {
+          setKnowledgeList(records);
+        } else {
+          // 加载更多时，合并新数据
+          setKnowledgeList((prev) => {
+            const existingIds = new Set(prev.map((item) => item.id));
+            const newItems = records.filter(
+              (item) => !existingIds.has(item.id),
+            );
+            return [...prev, ...newItems];
+          });
+        }
+      },
+    },
+  );
+
   // 广场-已发布智能体列表接口（智能体列表）
   const { loading: agentLoading, run: runAgentList } = useRequest(
     apiPublishedAgentList,
     {
       manual: true,
-      onSuccess: (
-        result: Page<SquarePublishedItemInfo>,
-        params?: SquarePublishedListParams[],
-      ) => {
+      onSuccess: (result: Page<SquarePublishedItemInfo>) => {
+        // 已发布智能体列表
         const records = result.records || [];
-        const currentPage = params?.[0]?.page || 1;
+        // 当前页码
+        const currentPage = result?.current ?? 1;
+        // 总页数
         const totalPages = result.pages || 0;
 
         // 判断是否还有更多数据
@@ -290,12 +379,11 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     apiPublishedAgentList,
     {
       manual: true,
-      onSuccess: (
-        result: Page<SquarePublishedItemInfo>,
-        params?: SquarePublishedListParams[],
-      ) => {
+      onSuccess: (result: Page<SquarePublishedItemInfo>) => {
         const records = result.records || [];
-        const currentPage = params?.[0]?.page || 1;
+        // 当前页码
+        const currentPage = result?.current ?? 1;
+        // 总页数
         const totalPages = result.pages || 0;
 
         // 判断是否还有更多数据
@@ -370,6 +458,14 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       setPagePage(1);
       setAgentHasMore(false);
       setPageHasMore(false);
+
+      // 重置知识库列表
+      setKnowledgeList([]);
+      setSelectedKnowledgeIds([]);
+      setSelectedKnowledgeList([]);
+      setKnowledgeSearchKw('');
+      setKnowledgePage(1);
+      setKnowledgeHasMore(false);
     }
   }, [open, targetId]);
 
@@ -443,6 +539,43 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     });
   };
 
+  // 查询知识库列表
+  const queryKnowledgeList = (page = 1, kw = knowledgeSearchKw) => {
+    runKnowledgeList({
+      pageNo: page,
+      pageSize: 20,
+      name: kw || undefined,
+      accessControl: AccessControlEnum.Filter,
+    });
+  };
+
+  // 知识库行选择配置（使用 targetId 作为选中 ID）
+  const toggleKnowledgeSelected = (targetId: number) => {
+    setSelectedKnowledgeIds((prev) => {
+      if (prev.includes(targetId)) {
+        return prev;
+      }
+      const newIds = [...prev, targetId];
+      if (newIds.length > 0) {
+        runGetKnowledgeListByIds({
+          knowledgeIds: newIds,
+        });
+      }
+      return newIds;
+    });
+  };
+
+  // 从右侧删除知识库
+  const removeKnowledgeFromSelected = (knowledgeId: number) => {
+    // 从右侧ID列表移除
+    setSelectedKnowledgeIds((prev) => prev.filter((id) => id !== knowledgeId));
+
+    // 从右侧列表移除
+    setSelectedKnowledgeList((prev) =>
+      prev.filter((item) => item.id !== knowledgeId),
+    );
+  };
+
   // 从右侧删除智能体，添加回左侧
   const removeAgentFromSelected = (agentId: number) => {
     // 从右侧ID列表移除
@@ -450,9 +583,6 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
 
     // 从右侧列表移除
     setSelectedAgentList((prev) => prev.filter((item) => item.id !== agentId));
-
-    // 重新搜索以获取该项并添加回左侧列表
-    queryAgentList();
   };
 
   // 应用页面行选择配置（使用 targetId 作为选中 ID）
@@ -550,6 +680,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         modelIds,
         agentIds: selectedAgentIds,
         pageAgentIds: selectedPageAgentIds,
+        knowledgeIds: selectedKnowledgeIds,
       },
     };
 
@@ -589,6 +720,17 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       if (pageList.length === 0 && !pageLoading) {
         // 查询网页应用列表
         queryPageList();
+      }
+    } else if (tabKey === 'knowledge') {
+      if (selectedKnowledgeIds.length > 0) {
+        runGetKnowledgeListByIds({
+          knowledgeIds: selectedKnowledgeIds,
+        });
+      } else {
+        setSelectedKnowledgeList([]);
+      }
+      if (knowledgeList.length === 0 && !knowledgeLoading) {
+        queryKnowledgeList();
       }
     }
   };
@@ -743,6 +885,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     </div>
   );
 
+  // 网页应用tab内容
   const PageTabContent = () => (
     <div className={cx('flex', 'h-full')}>
       {/* 左侧：搜索 + 可选网页应用列表（支持滚动加载） */}
@@ -831,6 +974,93 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           ))
         ) : (
           <div className={cx(styles.empty)}>暂无已选网页应用</div>
+        )}
+      </div>
+    </div>
+  );
+
+  const KnowledgeTabContent = () => (
+    <div className={cx('flex', 'h-full')}>
+      <div
+        className={cx(
+          'flex',
+          'flex-col',
+          'h-full',
+          'flex-1',
+          'overflow-hide',
+          styles.leftList,
+        )}
+      >
+        <Input.Search
+          key="knowledgeSearch"
+          placeholder="搜索知识库"
+          allowClear
+          className={cx(styles.searchInput)}
+          value={knowledgeSearchKw}
+          onChange={(e) => setKnowledgeSearchKw(e.target.value)}
+          onSearch={(value) => {
+            setKnowledgeSearchKw(value);
+            if (knowledgeListScrollRef.current) {
+              knowledgeListScrollRef.current.scrollTo({
+                top: 0,
+                behavior: 'smooth',
+              });
+            }
+            queryKnowledgeList(1, value);
+          }}
+        />
+        <div
+          ref={knowledgeListScrollRef}
+          id="knowledge-list-scroll"
+          className={cx('flex-1', 'overflow-y', 'h-full')}
+        >
+          {knowledgeLoading && !knowledgeList?.length ? (
+            <div
+              className={cx('h-full', 'flex', 'items-center', 'content-center')}
+            >
+              <Loading />
+            </div>
+          ) : (
+            <InfiniteScrollDiv
+              scrollableTarget="knowledge-list-scroll"
+              list={knowledgeList}
+              hasMore={knowledgeHasMore}
+              onScroll={() => {
+                if (!knowledgeLoading && knowledgeHasMore) {
+                  queryKnowledgeList(knowledgePage + 1);
+                }
+              }}
+            >
+              {knowledgeList?.map((item) => (
+                <ResourceItem
+                  key={item.id}
+                  showIcon={false}
+                  name={item.name}
+                  description={item.description}
+                  targetId={item.id}
+                  onAdd={toggleKnowledgeSelected}
+                  isAdded={selectedKnowledgeIds.includes(item.id)}
+                />
+              ))}
+            </InfiniteScrollDiv>
+          )}
+        </div>
+      </div>
+      <div className={cx(styles.rightSeparator)} />
+      <div className={cx(styles.rightList, 'flex-1')}>
+        {selectedKnowledgeList.length ? (
+          selectedKnowledgeList.map((item) => (
+            <ResourceItem
+              key={item.id}
+              showIcon={false}
+              name={item.name}
+              description={item.description}
+              targetId={item.id}
+              onDelete={removeKnowledgeFromSelected}
+            />
+          ))
+        ) : (
+          <div className={cx(styles.empty)}>暂无已选知识库</div>
         )}
       </div>
     </div>
@@ -1033,7 +1263,9 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       model: <ModelTabContent />,
       agent: <AgentTabContent />,
       page: <PageTabContent />,
+      knowledge: <KnowledgeTabContent />,
       dataPermission: <DataPermissionTabContent />,
+      apiPermission: null,
     };
     return contentMap[activeTab] ?? null;
   };

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -735,8 +735,9 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     }
   };
 
+  // 避免在父组件内定义子组件（每次渲染新函数引用会 remount 子树、丢失滚动）
   // 模型tab内容
-  const ModelTabContent = () => (
+  const modelTabContent = (
     <div className={cx('flex', 'h-full')}>
       {/* 左侧：可选模型列表 */}
       <div
@@ -792,7 +793,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   );
 
   // 智能体tab内容
-  const AgentTabContent = () => (
+  const agentTabContent = (
     <div className={cx('flex', 'h-full')}>
       {/* 左侧：搜索 + 可选智能体列表（支持滚动加载） */}
       <div
@@ -886,7 +887,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   );
 
   // 网页应用tab内容
-  const PageTabContent = () => (
+  const pageTabContent = (
     <div className={cx('flex', 'h-full')}>
       {/* 左侧：搜索 + 可选网页应用列表（支持滚动加载） */}
       <div
@@ -979,7 +980,8 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     </div>
   );
 
-  const KnowledgeTabContent = () => (
+  // 知识库tab内容
+  const knowledgeTabContent = (
     <div className={cx('flex', 'h-full')}>
       <div
         className={cx(
@@ -1000,12 +1002,14 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           onChange={(e) => setKnowledgeSearchKw(e.target.value)}
           onSearch={(value) => {
             setKnowledgeSearchKw(value);
+            // 平滑滚动到顶部
             if (knowledgeListScrollRef.current) {
               knowledgeListScrollRef.current.scrollTo({
                 top: 0,
                 behavior: 'smooth',
               });
             }
+            // 查询知识库列表
             queryKnowledgeList(1, value);
           }}
         />
@@ -1027,6 +1031,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
               hasMore={knowledgeHasMore}
               onScroll={() => {
                 if (!knowledgeLoading && knowledgeHasMore) {
+                  // 加载更多知识库列表
                   queryKnowledgeList(knowledgePage + 1);
                 }
               }}
@@ -1046,7 +1051,9 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           )}
         </div>
       </div>
+      {/* 分割线 */}
       <div className={cx(styles.rightSeparator)} />
+      {/* 右侧：已选择的知识库列表（通过ID列表查询） */}
       <div className={cx(styles.rightList, 'flex-1')}>
         {selectedKnowledgeList.length ? (
           selectedKnowledgeList.map((item) => (
@@ -1067,7 +1074,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   );
 
   // 开发权限tab内容
-  const DataPermissionTabContent = () => (
+  const dataPermissionTabContent = (
     <div className={cx(styles.dataPermissionFormWrapper)}>
       {/* 开发权限表单 */}
       <Form
@@ -1260,11 +1267,11 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   // 渲染tab内容
   const renderTabContent = () => {
     const contentMap: Record<DataPermissionTabKey, React.ReactNode> = {
-      model: <ModelTabContent />,
-      agent: <AgentTabContent />,
-      page: <PageTabContent />,
-      knowledge: <KnowledgeTabContent />,
-      dataPermission: <DataPermissionTabContent />,
+      model: modelTabContent,
+      agent: agentTabContent,
+      page: pageTabContent,
+      knowledge: knowledgeTabContent,
+      dataPermission: dataPermissionTabContent,
       apiPermission: null,
     };
     return contentMap[activeTab] ?? null;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -9,6 +9,10 @@ import {
   apiSystemResourceKnowledgeListByIds,
   apiSystemResourcePageListByIds,
 } from '@/pages/UserManage/user-manage';
+import {
+  apiGetOpenApiList,
+  OpenApiPermissionTargetTypeEnum,
+} from '@/services/account';
 import { apiPublishedAgentList } from '@/services/square';
 import {
   apiSystemModelList,
@@ -16,6 +20,7 @@ import {
 } from '@/services/systemManage';
 import { AgentComponentTypeEnum } from '@/types/enums/agent';
 import { AccessControlEnum } from '@/types/enums/systemManage';
+import type { OpenApiDefinition } from '@/types/interfaces/account';
 import type { AgentConfigInfo } from '@/types/interfaces/agent';
 import type { CustomPageDto } from '@/types/interfaces/pageDev';
 import type { Page } from '@/types/interfaces/request';
@@ -29,28 +34,32 @@ import type {
 import { InfoCircleOutlined } from '@ant-design/icons';
 import {
   Col,
+  Empty,
   Form,
   Input,
   InputNumber,
+  message,
   Modal,
   Row,
   Tabs,
   TabsProps,
   Tooltip,
-  message,
+  Tree,
+  Typography,
 } from 'antd';
 import classNames from 'classnames';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRequest } from 'umi';
 import {
   apiGetGroupBoundDataPermissionList,
   apiGroupBindDataPermission,
 } from '../../services/user-group-manage';
-import { DataPermission } from '../../types/role-manage';
+import { DataPermission, OpenApiConfigInfo } from '../../types/role-manage';
 import ResourceItem from './components/ResourceItem';
 import styles from './index.less';
 
 const cx = classNames.bind(styles);
+const { Text } = Typography;
 
 interface DataPermissionModalProps {
   /** 是否打开 */
@@ -128,14 +137,14 @@ export const DATA_PERMISSION_TAB_ITEMS: TabsProps['items'] = [
   },
   {
     key: 'dataPermission',
-    label: '开发权限',
+    label: '开发者权限',
   },
   {
     key: 'apiPermission',
     label: (
       <span>
         API权限
-        <Tooltip title="需授权才能使用API">
+        <Tooltip title="需授权才能使用API，可配置API接口调用频率限制（每分钟调用次数和每天调用次数，-1表示不限制，默认-1， 0表示无权限）">
           <InfoCircleOutlined
             style={{ marginLeft: 4, color: '#999', cursor: 'help' }}
           />
@@ -212,6 +221,21 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   // 保存表单值的状态，用于在组件卸载时保留值
   const [formValuesCache, setFormValuesCache] = useState<DataPermission>({});
 
+  // ============================= API 权限 Tab：可选 API 树 =============================
+  /** 左侧树数据，来自 apiGetOpenApiList（随 type 区分角色 / 用户组） */
+  const [openApiTreeData, setOpenApiTreeData] = useState<OpenApiDefinition[]>(
+    [],
+  );
+  /** 拉取开放 API 列表时的 loading */
+  const [openApiListLoading, setOpenApiListLoading] = useState<boolean>(false);
+  /**
+   * 开放 API 勾选与限流：列表中的项即勾选节点，含 key / rpm / rpd；
+   * 与数据权限接口的 openApiConfigs 一致，用于树勾选回显与提交。
+   */
+  const [openApiConfigsCache, setOpenApiConfigsCache] = useState<
+    OpenApiConfigInfo[]
+  >([]);
+
   // 模型列表
   const {
     data: modelList,
@@ -263,6 +287,8 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       setSelectedPageAgentIds(result?.pageAgentIds || []);
       // 回显知识库选择
       setSelectedKnowledgeIds(result?.knowledgeIds || []);
+      // 回显 API 权限选择
+      setOpenApiConfigsCache(result.openApiConfigs || []);
     },
   });
 
@@ -466,8 +492,121 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       setKnowledgeSearchKw('');
       setKnowledgePage(1);
       setKnowledgeHasMore(false);
+
+      // API 权限 Tab 状态重置（关闭弹窗时）
+      setOpenApiTreeData([]);
+      setOpenApiConfigsCache([]);
+      setOpenApiListLoading(false);
     }
   }, [open, targetId]);
+
+  /**
+   * 加载 API 权限左侧树数据。
+   * type 为 role 时传 OpenApiPermissionTargetTypeEnum.Role，否则传 Group。
+   * 树使用 defaultExpandAll，加载后全部展开。
+   */
+  const loadOpenApiTree = useCallback(async () => {
+    const targetType =
+      type === 'role'
+        ? OpenApiPermissionTargetTypeEnum.Role
+        : OpenApiPermissionTargetTypeEnum.Group;
+    setOpenApiListLoading(true);
+    try {
+      const res = await apiGetOpenApiList(targetType);
+      if (res.success && res.data) {
+        setOpenApiTreeData(res.data);
+      } else {
+        setOpenApiTreeData([]);
+      }
+    } catch (e) {
+      console.error(e);
+      setOpenApiTreeData([]);
+    } finally {
+      setOpenApiListLoading(false);
+    }
+  }, [type]);
+
+  /** 树勾选变化：用新勾选 key 集合重建列表，保留仍在勾选中的项的 rpm/rpd，新增项默认 0 */
+  const handleOpenApiTreeCheck = useCallback((keys: React.Key[] | any) => {
+    const raw = Array.isArray(keys) ? keys : keys.checked;
+    const keySet = new Set((raw as React.Key[]).map((k) => String(k)));
+    setOpenApiConfigsCache((prev) => {
+      const byKey = new Map(prev.map((c) => [c.key, c]));
+      const next: OpenApiConfigInfo[] = [];
+      keySet.forEach((key) => {
+        const existing = byKey.get(key);
+        next.push(
+          existing ?? {
+            key,
+            rpm: -1,
+            rpd: -1,
+          },
+        );
+      });
+      return next;
+    });
+  }, []);
+
+  /** 树节点标题：名称 + path（12px）；已勾选叶子右侧展示 RPM、RPD（读写 openApiConfigsCache） */
+  const openApiTitleRender = (node: OpenApiDefinition) => {
+    const isLeaf = !node.apiList?.length;
+    const cfg = openApiConfigsCache.find((c) => c.key === node.key);
+    return (
+      <div className={styles.openApiTreeTitleRow}>
+        <div className={styles.openApiTreeTitleLeft}>
+          <span
+            className={cx(styles.openApiTreeTitleName, 'text-ellipsis')}
+            title={node.name}
+          >
+            {node.name}
+          </span>
+          {node.path ? (
+            <span
+              className={cx(styles.openApiTreeTitlePath, 'text-ellipsis')}
+              title={node.path}
+            >
+              {node.path}
+            </span>
+          ) : null}
+        </div>
+        {isLeaf && cfg ? (
+          <div
+            className={styles.openApiTreeTitleControls}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Text className={styles['font-12']}>每分钟调用次数</Text>
+            <InputNumber
+              size="small"
+              min={-1}
+              className={styles['input-number']}
+              value={cfg.rpm}
+              onChange={(v) => {
+                setOpenApiConfigsCache((prev) =>
+                  prev.map((c) =>
+                    c.key === node.key ? { ...c, rpm: v ?? 0 } : c,
+                  ),
+                );
+              }}
+            />
+            <Text className={styles['font-12']}>每天调用次数</Text>
+            <InputNumber
+              size="small"
+              min={-1}
+              className={styles['input-number']}
+              value={cfg.rpd}
+              onChange={(v) => {
+                setOpenApiConfigsCache((prev) =>
+                  prev.map((c) =>
+                    c.key === node.key ? { ...c, rpd: v ?? 0 } : c,
+                  ),
+                );
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  };
 
   // 根据 selectedModelIds 更新 selectedModelList
   useEffect(() => {
@@ -523,7 +662,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       targetType: AgentComponentTypeEnum.Agent,
       targetSubType: 'ChatBot',
       kw,
-      accessControl: 1, // 访问控制过滤，0 无需过滤，1 过滤出需要权限管控的内容
+      accessControl: AccessControlEnum.Filter, // 访问控制过滤，0 无需过滤，1 过滤出需要权限管控的内容
     });
   };
 
@@ -535,7 +674,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       targetType: AgentComponentTypeEnum.Agent,
       targetSubType: 'PageApp',
       kw,
-      accessControl: 1, // 访问控制过滤，0 无需过滤，1 过滤出需要权限管控的内容
+      accessControl: AccessControlEnum.Filter, // 访问控制过滤，0 无需过滤，1 过滤出需要权限管控的内容
     });
   };
 
@@ -630,6 +769,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     },
   );
 
+  // 保存数据权限
   const handleOk = async () => {
     if (!targetId) {
       message.error('ID缺失，无法保存数据权限');
@@ -639,7 +779,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     // 优先使用缓存的值（即使字段被卸载，缓存的值仍然存在）
     let formValues: DataPermission = { ...formValuesCache };
 
-    // 如果当前在数据权限 tab，尝试验证并获取最新值
+    // 如果当前在开发者权限 tab，尝试验证并获取最新值
     if (activeTab === 'dataPermission') {
       try {
         const validatedValues = (await form.validateFields()) || {};
@@ -653,17 +793,15 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           formValues = currentValues;
           setFormValuesCache(currentValues);
         }
-        // 如果表单值也为空，继续使用缓存的值
       }
     } else {
-      // 不在数据权限 tab 时，尝试从表单获取最新值（如果字段还在）
+      // 不在开发者权限 tab 时，尝试从表单获取最新值（如果字段还在）
       const currentValues = form.getFieldsValue() || {};
       if (currentValues && Object.keys(currentValues).length > 0) {
         // 如果表单有值，使用表单值并更新缓存
         formValues = currentValues;
         setFormValuesCache(currentValues);
       }
-      // 如果表单值为空，使用缓存的值（已经在上面初始化了）
     }
 
     // 直接使用选中的模型ID数组
@@ -681,6 +819,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         agentIds: selectedAgentIds,
         pageAgentIds: selectedPageAgentIds,
         knowledgeIds: selectedKnowledgeIds,
+        openApiConfigs: openApiConfigsCache,
       },
     };
 
@@ -692,7 +831,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     const tabKey = key as DataPermissionTabKey;
     setActiveTab(tabKey);
 
-    // 只针对智能体和网页应用 tab 做额外处理
+    // 智能体 / 网页应用 / 知识库 / API 权限等 Tab 的按需加载
     if (tabKey === 'agent') {
       // 右侧：根据选中的ID列表查询已选择的智能体
       if (selectedAgentIds.length > 0) {
@@ -731,6 +870,11 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       }
       if (knowledgeList.length === 0 && !knowledgeLoading) {
         queryKnowledgeList();
+      }
+    } else if (tabKey === 'apiPermission') {
+      // 首次进入且尚无树数据时拉取列表（避免重复请求）
+      if (openApiTreeData.length === 0 && !openApiListLoading) {
+        loadOpenApiTree();
       }
     }
   };
@@ -1073,10 +1217,10 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     </div>
   );
 
-  // 开发权限tab内容
+  // 开发者权限tab内容
   const dataPermissionTabContent = (
     <div className={cx(styles.dataPermissionFormWrapper)}>
-      {/* 开发权限表单 */}
+      {/* 开发者权限表单 */}
       <Form
         form={form}
         layout="vertical"
@@ -1264,6 +1408,51 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     </div>
   );
 
+  /** API 权限 Tab：可勾选开放 API 树 */
+  const apiPermissionTabContent = (
+    <div className={cx('h-full', 'overflow-hide')}>
+      {openApiListLoading ? (
+        <div className={cx('h-full', 'flex', 'items-center', 'content-center')}>
+          <Loading />
+        </div>
+      ) : (
+        <div className={cx('h-full', 'overflow-y', 'py-16')}>
+          {openApiTreeData?.length > 0 ? (
+            <Tree
+              checkable
+              checkStrictly={false}
+              defaultExpandAll
+              checkedKeys={openApiConfigsCache.map((c) => c.key)}
+              onCheck={(keys) => {
+                // checkStrictly=false 时可能返回 { checked, halfChecked }
+                handleOpenApiTreeCheck(keys);
+              }}
+              treeData={openApiTreeData as any}
+              fieldNames={{ title: 'name', key: 'key', children: 'apiList' }}
+              titleRender={(node) =>
+                openApiTitleRender(node as OpenApiDefinition)
+              }
+              blockNode
+            />
+          ) : (
+            !openApiListLoading && (
+              <div
+                className={cx(
+                  'flex',
+                  'items-center',
+                  'content-center',
+                  'h-full',
+                )}
+              >
+                <Empty description="暂无 API 权限配置" />
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+
   // 渲染tab内容
   const renderTabContent = () => {
     const contentMap: Record<DataPermissionTabKey, React.ReactNode> = {
@@ -1272,7 +1461,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       page: pageTabContent,
       knowledge: knowledgeTabContent,
       dataPermission: dataPermissionTabContent,
-      apiPermission: null,
+      apiPermission: apiPermissionTabContent,
     };
     return contentMap[activeTab] ?? null;
   };

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -134,7 +134,7 @@ export const DATA_PERMISSION_TAB_ITEMS: TabsProps['items'] = [
     label: (
       <span>
         API权限
-        <Tooltip title="需授权才能使用API，可配置API接口调用频率限制（每分钟调用次数和每天调用次数，-1表示不限制，默认-1， 0表示无权限）">
+        <Tooltip title="开放API授权，可配置API接口调用频率限制，-1表示不限制">
           <InfoCircleOutlined
             style={{ marginLeft: 4, color: '#999', cursor: 'help' }}
           />

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -1,5 +1,3 @@
-import InfiniteScrollDiv from '@/components/custom/InfiniteScrollDiv';
-import Loading from '@/components/custom/Loading';
 import {
   apiGetRoleBoundDataPermissionList,
   apiRoleBindDataPermission,
@@ -32,21 +30,7 @@ import type {
   SystemKnowledgePage,
 } from '@/types/interfaces/systemManage';
 import { InfoCircleOutlined } from '@ant-design/icons';
-import {
-  Col,
-  Empty,
-  Form,
-  Input,
-  InputNumber,
-  message,
-  Modal,
-  Row,
-  Tabs,
-  TabsProps,
-  Tooltip,
-  Tree,
-  Typography,
-} from 'antd';
+import { Form, message, Modal, Tabs, TabsProps, Tooltip } from 'antd';
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRequest } from 'umi';
@@ -55,11 +39,17 @@ import {
   apiGroupBindDataPermission,
 } from '../../services/user-group-manage';
 import { DataPermission, OpenApiConfigInfo } from '../../types/role-manage';
-import ResourceItem from './components/ResourceItem';
 import styles from './index.less';
+import {
+  AgentTabPanel,
+  ApiPermissionTabPanel,
+  DeveloperPermissionFormTab,
+  KnowledgeTabPanel,
+  ModelTabPanel,
+  PageTabPanel,
+} from './tabPanels';
 
 const cx = classNames.bind(styles);
-const { Text } = Typography;
 
 interface DataPermissionModalProps {
   /** 是否打开 */
@@ -526,88 +516,6 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     }
   }, [type]);
 
-  /** 树勾选变化：用新勾选 key 集合重建列表，保留仍在勾选中的项的 rpm/rpd，新增项默认 0 */
-  const handleOpenApiTreeCheck = useCallback((keys: React.Key[] | any) => {
-    const raw = Array.isArray(keys) ? keys : keys.checked;
-    const keySet = new Set((raw as React.Key[]).map((k) => String(k)));
-    setOpenApiConfigsCache((prev) => {
-      const byKey = new Map(prev.map((c) => [c.key, c]));
-      const next: OpenApiConfigInfo[] = [];
-      keySet.forEach((key) => {
-        const existing = byKey.get(key);
-        next.push(
-          existing ?? {
-            key,
-            rpm: -1,
-            rpd: -1,
-          },
-        );
-      });
-      return next;
-    });
-  }, []);
-
-  /** 树节点标题：名称 + path（12px）；已勾选叶子右侧展示 RPM、RPD（读写 openApiConfigsCache） */
-  const openApiTitleRender = (node: OpenApiDefinition) => {
-    const isLeaf = !node.apiList?.length;
-    const cfg = openApiConfigsCache.find((c) => c.key === node.key);
-    return (
-      <div className={styles.openApiTreeTitleRow}>
-        <div className={styles.openApiTreeTitleLeft}>
-          <span
-            className={cx(styles.openApiTreeTitleName, 'text-ellipsis')}
-            title={node.name}
-          >
-            {node.name}
-          </span>
-          {node.path ? (
-            <span
-              className={cx(styles.openApiTreeTitlePath, 'text-ellipsis')}
-              title={node.path}
-            >
-              {node.path}
-            </span>
-          ) : null}
-        </div>
-        {isLeaf && cfg ? (
-          <div
-            className={styles.openApiTreeTitleControls}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Text className={styles['font-12']}>每分钟调用次数</Text>
-            <InputNumber
-              size="small"
-              min={-1}
-              className={styles['input-number']}
-              value={cfg.rpm}
-              onChange={(v) => {
-                setOpenApiConfigsCache((prev) =>
-                  prev.map((c) =>
-                    c.key === node.key ? { ...c, rpm: v ?? 0 } : c,
-                  ),
-                );
-              }}
-            />
-            <Text className={styles['font-12']}>每天调用次数</Text>
-            <InputNumber
-              size="small"
-              min={-1}
-              className={styles['input-number']}
-              value={cfg.rpd}
-              onChange={(v) => {
-                setOpenApiConfigsCache((prev) =>
-                  prev.map((c) =>
-                    c.key === node.key ? { ...c, rpd: v ?? 0 } : c,
-                  ),
-                );
-              }}
-            />
-          </div>
-        ) : null}
-      </div>
-    );
-  };
-
   // 根据 selectedModelIds 更新 selectedModelList
   useEffect(() => {
     if (modelList && modelList.length > 0 && selectedModelIds.length > 0) {
@@ -879,589 +787,83 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     }
   };
 
-  // 避免在父组件内定义子组件（每次渲染新函数引用会 remount 子树、丢失滚动）
-  // 模型tab内容
-  const modelTabContent = (
-    <div className={cx('flex', 'h-full')}>
-      {/* 左侧：可选模型列表 */}
-      <div
-        className={cx(
-          'flex',
-          'flex-col',
-          'h-full',
-          'flex-1',
-          'overflow-y',
-          styles.leftList,
-        )}
-      >
-        {modelLoading && !modelList?.length ? (
-          <div
-            className={cx('h-full', 'flex', 'items-center', 'content-center')}
-          >
-            <Loading />
-          </div>
-        ) : (
-          modelList?.map((item: ModelConfigDto) => (
-            <ResourceItem
-              key={item.id}
-              showIcon={false}
-              name={item.name}
-              description={item.description}
-              targetId={item.id}
-              onAdd={toggleModelSelected}
-              isAdded={selectedModelIds.includes(item.id)}
-            />
-          ))
-        )}
-      </div>
-      {/* 分割线 */}
-      <div className={cx(styles.rightSeparator)} />
-      {/* 右侧：已选择的模型列表 */}
-      <div className={cx(styles.rightList, 'flex-1')}>
-        {selectedModelList.length ? (
-          selectedModelList.map((item: ModelConfigDto) => (
-            <ResourceItem
-              key={item.id}
-              showIcon={false}
-              name={item.name}
-              description={item.description}
-              targetId={item.id}
-              onDelete={removeModelFromSelected}
-            />
-          ))
-        ) : (
-          <div className={cx(styles.empty)}>暂无已选模型</div>
-        )}
-      </div>
-    </div>
-  );
-
-  // 智能体tab内容
-  const agentTabContent = (
-    <div className={cx('flex', 'h-full')}>
-      {/* 左侧：搜索 + 可选智能体列表（支持滚动加载） */}
-      <div
-        className={cx(
-          'flex',
-          'flex-col',
-          'h-full',
-          'flex-1',
-          'overflow-hide',
-          styles.leftList,
-        )}
-      >
-        <Input.Search
-          key="agentSearch"
-          placeholder="搜索智能体"
-          allowClear
-          className={cx(styles.searchInput)}
-          value={agentSearchKw}
-          onChange={(e) => setAgentSearchKw(e.target.value)}
-          onSearch={(value) => {
-            setAgentSearchKw(value);
-            // 平滑滚动到顶部
-            if (agentListScrollRef.current) {
-              agentListScrollRef.current.scrollTo({
-                top: 0,
-                behavior: 'smooth',
-              });
-            }
-            // 查询智能体列表
-            queryAgentList(1, value);
-          }}
-        />
-        <div
-          ref={agentListScrollRef}
-          id="agent-list-scroll"
-          className={cx('flex-1', 'overflow-y', 'h-full')}
-        >
-          {agentLoading && !agentList?.length ? (
-            <div
-              className={cx('h-full', 'flex', 'items-center', 'content-center')}
-            >
-              <Loading />
-            </div>
-          ) : (
-            <InfiniteScrollDiv
-              scrollableTarget="agent-list-scroll"
-              list={agentList}
-              hasMore={agentHasMore}
-              onScroll={() => {
-                if (!agentLoading && agentHasMore) {
-                  // 查询智能体列表
-                  queryAgentList(agentPage + 1);
-                }
-              }}
-            >
-              {agentList?.map((item) => (
-                <ResourceItem
-                  key={item.targetId}
-                  icon={item.icon}
-                  name={item.name}
-                  description={item.description}
-                  targetId={item.targetId}
-                  onAdd={toggleAgentSelected}
-                  isAdded={selectedAgentIds.includes(item.targetId)}
-                />
-              ))}
-            </InfiniteScrollDiv>
-          )}
-        </div>
-      </div>
-      {/* 分割线 */}
-      <div className={cx(styles.rightSeparator)} />
-      {/* 右侧：已选择的智能体列表（通过ID列表查询） */}
-      <div className={cx(styles.rightList, 'flex-1')}>
-        {selectedAgentList.length ? (
-          selectedAgentList.map((item) => (
-            <ResourceItem
-              key={item.id}
-              icon={item.icon}
-              name={item.name}
-              description={item.description}
-              targetId={item.id}
-              onDelete={removeAgentFromSelected}
-            />
-          ))
-        ) : (
-          <div className={cx(styles.empty)}>暂无已选智能体</div>
-        )}
-      </div>
-    </div>
-  );
-
-  // 网页应用tab内容
-  const pageTabContent = (
-    <div className={cx('flex', 'h-full')}>
-      {/* 左侧：搜索 + 可选网页应用列表（支持滚动加载） */}
-      <div
-        className={cx(
-          'flex',
-          'flex-col',
-          'h-full',
-          'flex-1',
-          'overflow-hide',
-          styles.leftList,
-        )}
-      >
-        <Input.Search
-          key="pageSearch"
-          placeholder="搜索网页应用"
-          allowClear
-          className={cx(styles.searchInput)}
-          value={pageSearchKw}
-          onChange={(e) => setPageSearchKw(e.target.value)}
-          onSearch={(value) => {
-            setPageSearchKw(value);
-            // 平滑滚动到顶部
-            if (pageListScrollRef.current) {
-              pageListScrollRef.current.scrollTo({
-                top: 0,
-                behavior: 'smooth',
-              });
-            }
-            // 查询网页应用列表
-            queryPageList(1, value);
-          }}
-        />
-        <div
-          ref={pageListScrollRef}
-          id="page-list-scroll"
-          className={cx('flex-1', 'overflow-y', 'h-full')}
-        >
-          {pageLoading && !pageList?.length ? (
-            <div
-              className={cx('h-full', 'flex', 'items-center', 'content-center')}
-            >
-              <Loading />
-            </div>
-          ) : (
-            <InfiniteScrollDiv
-              scrollableTarget="page-list-scroll"
-              list={pageList}
-              hasMore={pageHasMore}
-              onScroll={() => {
-                if (!pageLoading && pageHasMore) {
-                  // 查询网页应用列表
-                  queryPageList(pagePage + 1);
-                }
-              }}
-            >
-              {pageList?.map((item) => (
-                <ResourceItem
-                  key={item.targetId}
-                  icon={item.coverImg || item.icon}
-                  name={item.name}
-                  description={item.description}
-                  targetId={item.targetId}
-                  onAdd={togglePageSelected}
-                  isAdded={selectedPageAgentIds.includes(item.targetId)}
-                />
-              ))}
-            </InfiniteScrollDiv>
-          )}
-        </div>
-      </div>
-      {/* 分割线 */}
-      <div className={cx(styles.rightSeparator)} />
-      {/* 右侧：已选择的网页应用列表（通过ID列表查询） */}
-      <div className={cx(styles.rightList, 'flex-1')}>
-        {selectedPageList.length ? (
-          selectedPageList.map((item) => (
-            <ResourceItem
-              key={item.devAgentId}
-              icon={item.coverImg || item.icon}
-              name={item.name}
-              description={item.description}
-              targetId={item.devAgentId}
-              onDelete={removePageFromSelected}
-            />
-          ))
-        ) : (
-          <div className={cx(styles.empty)}>暂无已选网页应用</div>
-        )}
-      </div>
-    </div>
-  );
-
-  // 知识库tab内容
-  const knowledgeTabContent = (
-    <div className={cx('flex', 'h-full')}>
-      <div
-        className={cx(
-          'flex',
-          'flex-col',
-          'h-full',
-          'flex-1',
-          'overflow-hide',
-          styles.leftList,
-        )}
-      >
-        <Input.Search
-          key="knowledgeSearch"
-          placeholder="搜索知识库"
-          allowClear
-          className={cx(styles.searchInput)}
-          value={knowledgeSearchKw}
-          onChange={(e) => setKnowledgeSearchKw(e.target.value)}
-          onSearch={(value) => {
-            setKnowledgeSearchKw(value);
-            // 平滑滚动到顶部
-            if (knowledgeListScrollRef.current) {
-              knowledgeListScrollRef.current.scrollTo({
-                top: 0,
-                behavior: 'smooth',
-              });
-            }
-            // 查询知识库列表
-            queryKnowledgeList(1, value);
-          }}
-        />
-        <div
-          ref={knowledgeListScrollRef}
-          id="knowledge-list-scroll"
-          className={cx('flex-1', 'overflow-y', 'h-full')}
-        >
-          {knowledgeLoading && !knowledgeList?.length ? (
-            <div
-              className={cx('h-full', 'flex', 'items-center', 'content-center')}
-            >
-              <Loading />
-            </div>
-          ) : (
-            <InfiniteScrollDiv
-              scrollableTarget="knowledge-list-scroll"
-              list={knowledgeList}
-              hasMore={knowledgeHasMore}
-              onScroll={() => {
-                if (!knowledgeLoading && knowledgeHasMore) {
-                  // 加载更多知识库列表
-                  queryKnowledgeList(knowledgePage + 1);
-                }
-              }}
-            >
-              {knowledgeList?.map((item) => (
-                <ResourceItem
-                  key={item.id}
-                  showIcon={false}
-                  name={item.name}
-                  description={item.description}
-                  targetId={item.id}
-                  onAdd={toggleKnowledgeSelected}
-                  isAdded={selectedKnowledgeIds.includes(item.id)}
-                />
-              ))}
-            </InfiniteScrollDiv>
-          )}
-        </div>
-      </div>
-      {/* 分割线 */}
-      <div className={cx(styles.rightSeparator)} />
-      {/* 右侧：已选择的知识库列表（通过ID列表查询） */}
-      <div className={cx(styles.rightList, 'flex-1')}>
-        {selectedKnowledgeList.length ? (
-          selectedKnowledgeList.map((item) => (
-            <ResourceItem
-              key={item.id}
-              showIcon={false}
-              name={item.name}
-              description={item.description}
-              targetId={item.id}
-              onDelete={removeKnowledgeFromSelected}
-            />
-          ))
-        ) : (
-          <div className={cx(styles.empty)}>暂无已选知识库</div>
-        )}
-      </div>
-    </div>
-  );
-
-  // 开发者权限tab内容
-  const dataPermissionTabContent = (
-    <div className={cx(styles.dataPermissionFormWrapper)}>
-      {/* 开发者权限表单 */}
-      <Form
-        form={form}
-        layout="vertical"
-        className={cx(styles.dataPermissionForm)}
-        preserve={true}
-        onValuesChange={(_, allValues) => {
-          setFormValuesCache((prev) => ({
-            ...prev,
-            ...allValues,
-          }));
-        }}
-      >
-        <Row gutter={[16, 0]}>
-          <Col span={12}>
-            <Form.Item
-              label="每日token限制"
-              name={['tokenLimit', 'limitPerDay']}
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '每日 token 限制，-1 表示不限制',
-              }}
-            >
-              <InputNumber
-                placeholder="请输入每日token限制数量"
-                className={cx('w-full')}
-                min={-1}
-                max={1000000000000000}
-              />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建工作空间数量"
-              name="maxSpaceCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建工作空间数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建智能体数量"
-              name="maxAgentCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建智能体数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建网页应用数量"
-              name="maxPageAppCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建网页应用数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建知识库数量"
-              name="maxKnowledgeCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建知识库数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="知识库存储空间上限 (GB)"
-              name="knowledgeStorageLimitGb"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title:
-                  '-1表示不限制, 0表示无权限, 精度为0.001GB, 1GB=1024MB, 1MB=1024KB',
-              }}
-            >
-              <InputNumber
-                className={cx('w-full')}
-                min={-1}
-                max={100000000}
-                step={0.001}
-                precision={3}
-                formatter={(value) => {
-                  if (value === undefined || value === null) return '';
-                  const num = Number(value);
-                  if (Number.isInteger(num)) return String(num);
-                  return num.toFixed(3).replace(/\.?0+$/, '');
-                }}
-                parser={(value) => {
-                  if (!value) return value as any;
-                  const num = parseFloat(value);
-                  return isNaN(num) ? (value as any) : num;
-                }}
-              />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建数据表数量"
-              name="maxDataTableCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建数据表数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="可创建定时任务数量"
-              name="maxScheduledTaskCount"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '可创建定时任务数量，-1 表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="智能体电脑内存(GB)"
-              name="agentComputerMemoryGb"
-              initialValue={4}
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '智能体电脑内存 (GB，留空表示使用默认值4GB)',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="智能体电脑 CPU 核心数"
-              name="agentComputerCpuCores"
-              initialValue={2}
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '智能体电脑 CPU 核心数（留空表示使用默认值）',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="通用智能体每天对话次数限制"
-              name="agentDailyPromptLimit"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '通用智能体每天对话次数，-1表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-          <Col span={12}>
-            <Form.Item
-              label="网页应用开发每天对话次数"
-              name="pageDailyPromptLimit"
-              tooltip={{
-                icon: <InfoCircleOutlined />,
-                title: '网页应用开发每天对话次数，-1表示不限制',
-              }}
-            >
-              <InputNumber className={cx('w-full')} min={-1} max={100000000} />
-            </Form.Item>
-          </Col>
-        </Row>
-      </Form>
-    </div>
-  );
-
-  /** API 权限 Tab：可勾选开放 API 树 */
-  const apiPermissionTabContent = (
-    <div className={cx('h-full', 'overflow-hide')}>
-      {openApiListLoading ? (
-        <div className={cx('h-full', 'flex', 'items-center', 'content-center')}>
-          <Loading />
-        </div>
-      ) : (
-        <div className={cx('h-full', 'overflow-y', 'py-16')}>
-          {openApiTreeData?.length > 0 ? (
-            <Tree
-              checkable
-              checkStrictly={false}
-              defaultExpandAll
-              checkedKeys={openApiConfigsCache.map((c) => c.key)}
-              onCheck={(keys) => {
-                // checkStrictly=false 时可能返回 { checked, halfChecked }
-                handleOpenApiTreeCheck(keys);
-              }}
-              treeData={openApiTreeData as any}
-              fieldNames={{ title: 'name', key: 'key', children: 'apiList' }}
-              titleRender={(node) =>
-                openApiTitleRender(node as OpenApiDefinition)
-              }
-              blockNode
-            />
-          ) : (
-            !openApiListLoading && (
-              <div
-                className={cx(
-                  'flex',
-                  'items-center',
-                  'content-center',
-                  'h-full',
-                )}
-              >
-                <Empty description="暂无 API 权限配置" />
-              </div>
-            )
-          )}
-        </div>
-      )}
-    </div>
-  );
-
-  // 渲染tab内容
+  // 各 Tab 内容拆至 tabPanels/，避免单文件过长
   const renderTabContent = () => {
     const contentMap: Record<DataPermissionTabKey, React.ReactNode> = {
-      model: modelTabContent,
-      agent: agentTabContent,
-      page: pageTabContent,
-      knowledge: knowledgeTabContent,
-      dataPermission: dataPermissionTabContent,
-      apiPermission: apiPermissionTabContent,
+      model: (
+        <ModelTabPanel
+          modelLoading={modelLoading}
+          modelList={modelList}
+          selectedModelIds={selectedModelIds}
+          selectedModelList={selectedModelList}
+          onToggleModel={toggleModelSelected}
+          onRemoveModel={removeModelFromSelected}
+        />
+      ),
+      agent: (
+        <AgentTabPanel
+          agentSearchKw={agentSearchKw}
+          onAgentSearchKwChange={setAgentSearchKw}
+          onAgentSearch={(v) => queryAgentList(1, v)}
+          agentListScrollRef={agentListScrollRef}
+          agentLoading={agentLoading}
+          agentList={agentList}
+          agentHasMore={agentHasMore}
+          onLoadMoreAgent={() => queryAgentList(agentPage + 1)}
+          selectedAgentIds={selectedAgentIds}
+          selectedAgentList={selectedAgentList}
+          onToggleAgent={toggleAgentSelected}
+          onRemoveAgent={removeAgentFromSelected}
+        />
+      ),
+      page: (
+        <PageTabPanel
+          pageSearchKw={pageSearchKw}
+          onPageSearchKwChange={setPageSearchKw}
+          onPageSearch={(v) => queryPageList(1, v)}
+          pageListScrollRef={pageListScrollRef}
+          pageLoading={pageLoading}
+          pageList={pageList}
+          pageHasMore={pageHasMore}
+          onLoadMorePage={() => queryPageList(pagePage + 1)}
+          selectedPageAgentIds={selectedPageAgentIds}
+          selectedPageList={selectedPageList}
+          onTogglePage={togglePageSelected}
+          onRemovePage={removePageFromSelected}
+        />
+      ),
+      knowledge: (
+        <KnowledgeTabPanel
+          knowledgeSearchKw={knowledgeSearchKw}
+          onKnowledgeSearchKwChange={setKnowledgeSearchKw}
+          onKnowledgeSearch={(v) => queryKnowledgeList(1, v)}
+          knowledgeListScrollRef={knowledgeListScrollRef}
+          knowledgeLoading={knowledgeLoading}
+          knowledgeList={knowledgeList}
+          knowledgeHasMore={knowledgeHasMore}
+          onLoadMoreKnowledge={() => queryKnowledgeList(knowledgePage + 1)}
+          selectedKnowledgeIds={selectedKnowledgeIds}
+          selectedKnowledgeList={selectedKnowledgeList}
+          onToggleKnowledge={toggleKnowledgeSelected}
+          onRemoveKnowledge={removeKnowledgeFromSelected}
+        />
+      ),
+      dataPermission: (
+        <DeveloperPermissionFormTab
+          form={form}
+          onValuesChange={(allValues) =>
+            setFormValuesCache((prev) => ({ ...prev, ...allValues }))
+          }
+        />
+      ),
+      apiPermission: (
+        <ApiPermissionTabPanel
+          openApiListLoading={openApiListLoading}
+          openApiTreeData={openApiTreeData}
+          openApiConfigsCache={openApiConfigsCache}
+          setOpenApiConfigsCache={setOpenApiConfigsCache}
+        />
+      ),
     };
     return contentMap[activeTab] ?? null;
   };

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/index.tsx
@@ -740,50 +740,49 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     setActiveTab(tabKey);
 
     // 智能体 / 网页应用 / 知识库 / API 权限等 Tab 的按需加载
-    if (tabKey === 'agent') {
-      // 右侧：根据选中的ID列表查询已选择的智能体
-      if (selectedAgentIds.length > 0) {
-        runGetAgentListByIds({
-          agentIds: selectedAgentIds,
-        });
-      } else {
-        setSelectedAgentList([]);
-      }
-      // 首次切换到智能体 tab 时，加载第一页数据
-      if (agentList.length === 0 && !agentLoading) {
-        // 查询智能体列表
-        queryAgentList();
-      }
-    } else if (tabKey === 'page') {
-      // 右侧：根据选中的ID列表查询已选择的网页应用
-      if (selectedPageAgentIds.length > 0) {
-        runGetPageListByIds({
-          agentIds: selectedPageAgentIds,
-        });
-      } else {
-        setSelectedPageList([]);
-      }
-      // 首次切换到网页应用 tab 时，加载第一页数据
-      if (pageList.length === 0 && !pageLoading) {
-        // 查询网页应用列表
-        queryPageList();
-      }
-    } else if (tabKey === 'knowledge') {
-      if (selectedKnowledgeIds.length > 0) {
-        runGetKnowledgeListByIds({
-          knowledgeIds: selectedKnowledgeIds,
-        });
-      } else {
-        setSelectedKnowledgeList([]);
-      }
-      if (knowledgeList.length === 0 && !knowledgeLoading) {
-        queryKnowledgeList();
-      }
-    } else if (tabKey === 'apiPermission') {
-      // 首次进入且尚无树数据时拉取列表（避免重复请求）
-      if (openApiTreeData.length === 0 && !openApiListLoading) {
-        loadOpenApiTree();
-      }
+    switch (tabKey) {
+      case 'agent':
+        // 右侧：根据选中的ID列表查询已选择的智能体
+        if (selectedAgentIds.length > 0) {
+          runGetAgentListByIds({
+            agentIds: selectedAgentIds,
+          });
+        }
+        // 首次切换到智能体 tab 时，加载第一页数据
+        if (agentList.length === 0 && !agentLoading) {
+          queryAgentList();
+        }
+        break;
+      case 'page':
+        // 右侧：根据选中的ID列表查询已选择的网页应用
+        if (selectedPageAgentIds.length > 0) {
+          runGetPageListByIds({
+            agentIds: selectedPageAgentIds,
+          });
+        }
+        // 首次切换到网页应用 tab 时，加载第一页数据
+        if (pageList.length === 0 && !pageLoading) {
+          queryPageList();
+        }
+        break;
+      case 'knowledge':
+        if (selectedKnowledgeIds.length > 0) {
+          runGetKnowledgeListByIds({
+            knowledgeIds: selectedKnowledgeIds,
+          });
+        }
+        if (knowledgeList.length === 0 && !knowledgeLoading) {
+          queryKnowledgeList();
+        }
+        break;
+      case 'apiPermission':
+        // 首次进入且尚无树数据时拉取列表（避免重复请求）
+        if (openApiTreeData.length === 0 && !openApiListLoading) {
+          loadOpenApiTree();
+        }
+        break;
+      default:
+        break;
     }
   };
 

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/AgentTabPanel.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/AgentTabPanel.tsx
@@ -1,0 +1,151 @@
+/**
+ * 数据权限弹窗 —「智能体」Tab 面板
+ *
+ * 功能：顶部搜索；左侧广场智能体列表支持无限滚动加载；右侧展示按 id 拉取的已选智能体详情。
+ * 滚动容器 id 为 `agent-list-scroll`，需与 InfiniteScrollDiv 的 scrollableTarget 一致。
+ *
+ * @see DataPermissionModal
+ */
+import InfiniteScrollDiv from '@/components/custom/InfiniteScrollDiv';
+import Loading from '@/components/custom/Loading';
+import type { AgentConfigInfo } from '@/types/interfaces/agent';
+import type { SquarePublishedItemInfo } from '@/types/interfaces/square';
+import { Input } from 'antd';
+import classNames from 'classnames';
+import React, { RefObject } from 'react';
+import ResourceItem from '../components/ResourceItem';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+
+/** 智能体 Tab：搜索关键词、分页列表与选中列表由父组件管理 */
+export interface AgentTabPanelProps {
+  /** 搜索框受控值 */
+  agentSearchKw: string;
+  /** 更新搜索关键词（输入框 onChange） */
+  onAgentSearchKwChange: (v: string) => void;
+  /** 触发搜索（回车/搜索按钮），通常请求第一页并传 keyword */
+  onAgentSearch: (value: string) => void;
+  /** 左侧列表滚动容器 ref，搜索时用于 scrollTo 顶部 */
+  agentListScrollRef: RefObject<HTMLDivElement>;
+  /** 列表请求加载中 */
+  agentLoading: boolean;
+  /** 当前页合并后的广场智能体列表 */
+  agentList: SquarePublishedItemInfo[];
+  /** 是否还有下一页 */
+  agentHasMore: boolean;
+  /** 触底加载下一页（父组件内应拼接页码并发起请求） */
+  onLoadMoreAgent: () => void;
+  /** 已选智能体 id（左侧 isAdded） */
+  selectedAgentIds: number[];
+  /** 右侧已选详情（由父组件按 id 批量查询） */
+  selectedAgentList: AgentConfigInfo[];
+  /** 加入已选 */
+  onToggleAgent: (targetId: number) => void;
+  /** 从已选移除 */
+  onRemoveAgent: (agentId: number) => void;
+}
+
+const AgentTabPanel: React.FC<AgentTabPanelProps> = ({
+  agentSearchKw,
+  onAgentSearchKwChange,
+  onAgentSearch,
+  agentListScrollRef,
+  agentLoading,
+  agentList,
+  agentHasMore,
+  onLoadMoreAgent,
+  selectedAgentIds,
+  selectedAgentList,
+  onToggleAgent,
+  onRemoveAgent,
+}) => (
+  <div className={cx('flex', 'h-full')}>
+    {/* 左侧：搜索 + 可滚动列表（InfiniteScroll） */}
+    <div
+      className={cx(
+        'flex',
+        'flex-col',
+        'h-full',
+        'flex-1',
+        'overflow-hide',
+        styles.leftList,
+      )}
+    >
+      <Input.Search
+        key="agentSearch"
+        placeholder="搜索智能体"
+        allowClear
+        className={cx(styles.searchInput)}
+        value={agentSearchKw}
+        onChange={(e) => onAgentSearchKwChange(e.target.value)}
+        onSearch={(value) => {
+          onAgentSearchKwChange(value);
+          if (agentListScrollRef.current) {
+            agentListScrollRef.current.scrollTo({
+              top: 0,
+              behavior: 'smooth',
+            });
+          }
+          onAgentSearch(value);
+        }}
+      />
+      <div
+        ref={agentListScrollRef}
+        id="agent-list-scroll"
+        className={cx('flex-1', 'overflow-y', 'h-full')}
+      >
+        {agentLoading && !agentList?.length ? (
+          <div
+            className={cx('h-full', 'flex', 'items-center', 'content-center')}
+          >
+            <Loading />
+          </div>
+        ) : (
+          <InfiniteScrollDiv
+            scrollableTarget="agent-list-scroll"
+            list={agentList}
+            hasMore={agentHasMore}
+            onScroll={() => {
+              if (!agentLoading && agentHasMore) {
+                onLoadMoreAgent();
+              }
+            }}
+          >
+            {agentList?.map((item) => (
+              <ResourceItem
+                key={item.targetId}
+                icon={item.icon}
+                name={item.name}
+                description={item.description}
+                targetId={item.targetId}
+                onAdd={onToggleAgent}
+                isAdded={selectedAgentIds.includes(item.targetId)}
+              />
+            ))}
+          </InfiniteScrollDiv>
+        )}
+      </div>
+    </div>
+    <div className={cx(styles.rightSeparator)} />
+    {/* 右侧：已选智能体 */}
+    <div className={cx(styles.rightList, 'flex-1')}>
+      {selectedAgentList.length ? (
+        selectedAgentList.map((item) => (
+          <ResourceItem
+            key={item.id}
+            icon={item.icon}
+            name={item.name}
+            description={item.description}
+            targetId={item.id}
+            onDelete={onRemoveAgent}
+          />
+        ))
+      ) : (
+        <div className={cx(styles.empty)}>暂无已选智能体</div>
+      )}
+    </div>
+  </div>
+);
+
+export default AgentTabPanel;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/ApiPermissionTabPanel.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/ApiPermissionTabPanel.tsx
@@ -1,0 +1,173 @@
+/**
+ * 数据权限弹窗 —「API 权限」Tab 面板
+ *
+ * 功能：展示开放 API 树（可勾选）；勾选结果写入 openApiConfigsCache（含 key、rpm、rpd）。
+ * 叶子节点可在标题行编辑每分钟/每天调用次数；-1 表示不限制（含义与业务 tooltip 一致）。
+ * 树数据由父组件拉取后传入；本组件内处理勾选合并与标题渲染。
+ *
+ * @see DataPermissionModal
+ */
+import Loading from '@/components/custom/Loading';
+import type { OpenApiDefinition } from '@/types/interfaces/account';
+import { Empty, InputNumber, Tree, Typography } from 'antd';
+import classNames from 'classnames';
+import React, { useCallback } from 'react';
+import type { OpenApiConfigInfo } from '../../../types/role-manage';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+const { Text } = Typography;
+
+/** API 权限 Tab：开放 API 树 + 勾选配置缓存 */
+export interface ApiPermissionTabPanelProps {
+  /** 拉取开放 API 列表中 */
+  openApiListLoading: boolean;
+  /** 接口返回的树形数据（字段 name/key/apiList） */
+  openApiTreeData: OpenApiDefinition[];
+  /** 当前勾选的 API 及其 RPM/RPD，与保存参数 openApiConfigs 对应 */
+  openApiConfigsCache: OpenApiConfigInfo[];
+  setOpenApiConfigsCache: React.Dispatch<
+    React.SetStateAction<OpenApiConfigInfo[]>
+  >;
+}
+
+const ApiPermissionTabPanel: React.FC<ApiPermissionTabPanelProps> = ({
+  openApiListLoading,
+  openApiTreeData,
+  openApiConfigsCache,
+  setOpenApiConfigsCache,
+}) => {
+  /** 勾选变化：按新 key 集合重建列表，保留仍选中项的 rpm/rpd，新增项默认 -1 */
+  const handleOpenApiTreeCheck = useCallback(
+    (
+      keys: React.Key[] | { checked: React.Key[]; halfChecked?: React.Key[] },
+    ) => {
+      const raw = Array.isArray(keys) ? keys : keys.checked;
+      const keySet = new Set((raw as React.Key[]).map((k) => String(k)));
+      setOpenApiConfigsCache((prev) => {
+        const byKey = new Map(prev.map((c) => [c.key, c]));
+        const next: OpenApiConfigInfo[] = [];
+        keySet.forEach((key) => {
+          const existing = byKey.get(key);
+          next.push(
+            existing ?? {
+              key,
+              rpm: -1,
+              rpd: -1,
+            },
+          );
+        });
+        return next;
+      });
+    },
+    [setOpenApiConfigsCache],
+  );
+
+  /** 树节点标题：名称 + path；叶子且已勾选时展示 RPM/RPD 输入 */
+  const openApiTitleRender = useCallback(
+    (node: OpenApiDefinition) => {
+      const isLeaf = !node.apiList?.length;
+      const cfg = openApiConfigsCache.find((c) => c.key === node.key);
+      return (
+        <div className={styles.openApiTreeTitleRow}>
+          <div className={styles.openApiTreeTitleLeft}>
+            <span
+              className={cx(styles.openApiTreeTitleName, 'text-ellipsis')}
+              title={node.name}
+            >
+              {node.name}
+            </span>
+            {node.path ? (
+              <span
+                className={cx(styles.openApiTreeTitlePath, 'text-ellipsis')}
+                title={node.path}
+              >
+                {node.path}
+              </span>
+            ) : null}
+          </div>
+          {isLeaf && cfg ? (
+            <div
+              className={styles.openApiTreeTitleControls}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Text className={styles['font-12']}>每分钟调用次数</Text>
+              <InputNumber
+                size="small"
+                min={-1}
+                className={styles['input-number']}
+                value={cfg.rpm}
+                onChange={(v) => {
+                  setOpenApiConfigsCache((prev) =>
+                    prev.map((c) =>
+                      c.key === node.key ? { ...c, rpm: v ?? 0 } : c,
+                    ),
+                  );
+                }}
+              />
+              <Text className={styles['font-12']}>每天调用次数</Text>
+              <InputNumber
+                size="small"
+                min={-1}
+                className={styles['input-number']}
+                value={cfg.rpd}
+                onChange={(v) => {
+                  setOpenApiConfigsCache((prev) =>
+                    prev.map((c) =>
+                      c.key === node.key ? { ...c, rpd: v ?? 0 } : c,
+                    ),
+                  );
+                }}
+              />
+            </div>
+          ) : null}
+        </div>
+      );
+    },
+    [openApiConfigsCache, setOpenApiConfigsCache],
+  );
+
+  return (
+    <div className={cx('h-full', 'overflow-hide')}>
+      {/* 加载完成后展示可滚动区域内的树或空态 */}
+      {openApiListLoading ? (
+        <div className={cx('h-full', 'flex', 'items-center', 'content-center')}>
+          <Loading />
+        </div>
+      ) : (
+        <div className={cx('h-full', 'overflow-y', 'py-16')}>
+          {openApiTreeData?.length > 0 ? (
+            <Tree
+              checkable
+              checkStrictly={false}
+              defaultExpandAll
+              checkedKeys={openApiConfigsCache.map((c) => c.key)}
+              onCheck={(keys) => handleOpenApiTreeCheck(keys as any)}
+              treeData={openApiTreeData as any}
+              fieldNames={{ title: 'name', key: 'key', children: 'apiList' }}
+              titleRender={(node) =>
+                openApiTitleRender(node as OpenApiDefinition)
+              }
+              blockNode
+            />
+          ) : (
+            !openApiListLoading && (
+              <div
+                className={cx(
+                  'flex',
+                  'items-center',
+                  'content-center',
+                  'h-full',
+                )}
+              >
+                <Empty description="暂无 API 权限配置" />
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApiPermissionTabPanel;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/DeveloperPermissionFormTab.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/DeveloperPermissionFormTab.tsx
@@ -1,0 +1,217 @@
+/**
+ * 数据权限弹窗 —「开发者权限」Tab 面板
+ *
+ * 功能：展示与编辑 DataPermission 中的数值型配额（token、各资源上限、智能体电脑规格、对话次数等）。
+ * 使用 antd Form，实例与初始值由父组件传入；字段变更通过 onValuesChange 同步到父级缓存，便于非本 Tab 时保存仍能带上表单数据。
+ *
+ * @see DataPermissionModal
+ */
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Col, Form, InputNumber, Row } from 'antd';
+import type { FormInstance } from 'antd/es/form';
+import classNames from 'classnames';
+import React from 'react';
+import type { DataPermission } from '../../../types/role-manage';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+
+export interface DeveloperPermissionFormTabProps {
+  /** 与父组件共用的 Form 实例（含 setFieldsValue / validateFields） */
+  form: FormInstance;
+  /** 任意字段变化时回传当前表单聚合值，供父组件写入 formValuesCache */
+  onValuesChange: (allValues: DataPermission) => void;
+}
+
+/** 开发者权限配额表单（无状态展示层，状态在 Form 与父组件） */
+const DeveloperPermissionFormTab: React.FC<DeveloperPermissionFormTabProps> = ({
+  form,
+  onValuesChange,
+}) => (
+  <div className={cx(styles.dataPermissionFormWrapper)}>
+    <Form
+      form={form}
+      layout="vertical"
+      className={cx(styles.dataPermissionForm)}
+      preserve
+      onValuesChange={(_, allValues) =>
+        onValuesChange(allValues as DataPermission)
+      }
+    >
+      {/* 两列栅格排布各项配额 InputNumber */}
+      <Row gutter={[16, 0]}>
+        <Col span={12}>
+          <Form.Item
+            label="每日token限制"
+            name={['tokenLimit', 'limitPerDay']}
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '每日 token 限制，-1 表示不限制',
+            }}
+          >
+            <InputNumber
+              placeholder="请输入每日token限制数量"
+              className={cx('w-full')}
+              min={-1}
+              max={1000000000000000}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建工作空间数量"
+            name="maxSpaceCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建工作空间数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建智能体数量"
+            name="maxAgentCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建智能体数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建网页应用数量"
+            name="maxPageAppCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建网页应用数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建知识库数量"
+            name="maxKnowledgeCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建知识库数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="知识库存储空间上限 (GB)"
+            name="knowledgeStorageLimitGb"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title:
+                '-1表示不限制, 0表示无权限, 精度为0.001GB, 1GB=1024MB, 1MB=1024KB',
+            }}
+          >
+            <InputNumber
+              className={cx('w-full')}
+              min={-1}
+              max={100000000}
+              step={0.001}
+              precision={3}
+              formatter={(value) => {
+                if (value === undefined || value === null) return '';
+                const num = Number(value);
+                if (Number.isInteger(num)) return String(num);
+                return num.toFixed(3).replace(/\.?0+$/, '');
+              }}
+              parser={(value) => {
+                if (!value) return value as any;
+                const num = parseFloat(value);
+                return isNaN(num) ? (value as any) : num;
+              }}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建数据表数量"
+            name="maxDataTableCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建数据表数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="可创建定时任务数量"
+            name="maxScheduledTaskCount"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '可创建定时任务数量，-1 表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="智能体电脑内存(GB)"
+            name="agentComputerMemoryGb"
+            initialValue={4}
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '智能体电脑内存 (GB，留空表示使用默认值4GB)',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="智能体电脑 CPU 核心数"
+            name="agentComputerCpuCores"
+            initialValue={2}
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '智能体电脑 CPU 核心数（留空表示使用默认值）',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="通用智能体每天对话次数限制"
+            name="agentDailyPromptLimit"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '通用智能体每天对话次数，-1表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            label="网页应用开发每天对话次数"
+            name="pageDailyPromptLimit"
+            tooltip={{
+              icon: <InfoCircleOutlined />,
+              title: '网页应用开发每天对话次数，-1表示不限制',
+            }}
+          >
+            <InputNumber className={cx('w-full')} min={-1} max={100000000} />
+          </Form.Item>
+        </Col>
+      </Row>
+    </Form>
+  </div>
+);
+
+export default DeveloperPermissionFormTab;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/KnowledgeTabPanel.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/KnowledgeTabPanel.tsx
@@ -1,0 +1,149 @@
+/**
+ * 数据权限弹窗 —「知识库」Tab 面板
+ *
+ * 功能：搜索 + 左侧系统知识库分页列表（无限滚动）；右侧为按 id 查询的已选知识库详情。
+ * 左侧列表项使用知识库 id 作为 targetId，与 selectedKnowledgeIds 对齐。
+ *
+ * @see DataPermissionModal
+ */
+import InfiniteScrollDiv from '@/components/custom/InfiniteScrollDiv';
+import Loading from '@/components/custom/Loading';
+import type {
+  KnowledgeInfoById,
+  SystemKnowledgeInfo,
+} from '@/types/interfaces/systemManage';
+import { Input } from 'antd';
+import classNames from 'classnames';
+import React, { RefObject } from 'react';
+import ResourceItem from '../components/ResourceItem';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+
+/** 知识库 Tab：搜索、分页与选中由父组件管理 */
+export interface KnowledgeTabPanelProps {
+  /** 搜索框受控值 */
+  knowledgeSearchKw: string;
+  onKnowledgeSearchKwChange: (v: string) => void;
+  /** 搜索第一页 */
+  onKnowledgeSearch: (value: string) => void;
+  /** 左侧列表滚动容器 */
+  knowledgeListScrollRef: RefObject<HTMLDivElement>;
+  knowledgeLoading: boolean;
+  knowledgeList: SystemKnowledgeInfo[];
+  knowledgeHasMore: boolean;
+  /** 触底加载下一页 */
+  onLoadMoreKnowledge: () => void;
+  /** 已选知识库 id */
+  selectedKnowledgeIds: number[];
+  /** 右侧已选详情 */
+  selectedKnowledgeList: KnowledgeInfoById[];
+  /** 加入已选 */
+  onToggleKnowledge: (targetId: number) => void;
+  /** 从已选移除 */
+  onRemoveKnowledge: (knowledgeId: number) => void;
+}
+
+const KnowledgeTabPanel: React.FC<KnowledgeTabPanelProps> = ({
+  knowledgeSearchKw,
+  onKnowledgeSearchKwChange,
+  onKnowledgeSearch,
+  knowledgeListScrollRef,
+  knowledgeLoading,
+  knowledgeList,
+  knowledgeHasMore,
+  onLoadMoreKnowledge,
+  selectedKnowledgeIds,
+  selectedKnowledgeList,
+  onToggleKnowledge,
+  onRemoveKnowledge,
+}) => (
+  <div className={cx('flex', 'h-full')}>
+    {/* 左侧：搜索 + 知识库列表（无限滚动，scrollTarget: knowledge-list-scroll） */}
+    <div
+      className={cx(
+        'flex',
+        'flex-col',
+        'h-full',
+        'flex-1',
+        'overflow-hide',
+        styles.leftList,
+      )}
+    >
+      <Input.Search
+        key="knowledgeSearch"
+        placeholder="搜索知识库"
+        allowClear
+        className={cx(styles.searchInput)}
+        value={knowledgeSearchKw}
+        onChange={(e) => onKnowledgeSearchKwChange(e.target.value)}
+        onSearch={(value) => {
+          onKnowledgeSearchKwChange(value);
+          if (knowledgeListScrollRef.current) {
+            knowledgeListScrollRef.current.scrollTo({
+              top: 0,
+              behavior: 'smooth',
+            });
+          }
+          onKnowledgeSearch(value);
+        }}
+      />
+      <div
+        ref={knowledgeListScrollRef}
+        id="knowledge-list-scroll"
+        className={cx('flex-1', 'overflow-y', 'h-full')}
+      >
+        {knowledgeLoading && !knowledgeList?.length ? (
+          <div
+            className={cx('h-full', 'flex', 'items-center', 'content-center')}
+          >
+            <Loading />
+          </div>
+        ) : (
+          <InfiniteScrollDiv
+            scrollableTarget="knowledge-list-scroll"
+            list={knowledgeList}
+            hasMore={knowledgeHasMore}
+            onScroll={() => {
+              if (!knowledgeLoading && knowledgeHasMore) {
+                onLoadMoreKnowledge();
+              }
+            }}
+          >
+            {knowledgeList?.map((item) => (
+              <ResourceItem
+                key={item.id}
+                showIcon={false}
+                name={item.name}
+                description={item.description}
+                targetId={item.id}
+                onAdd={onToggleKnowledge}
+                isAdded={selectedKnowledgeIds.includes(item.id)}
+              />
+            ))}
+          </InfiniteScrollDiv>
+        )}
+      </div>
+    </div>
+    <div className={cx(styles.rightSeparator)} />
+    {/* 右侧：已选知识库 */}
+    <div className={cx(styles.rightList, 'flex-1')}>
+      {selectedKnowledgeList.length ? (
+        selectedKnowledgeList.map((item) => (
+          <ResourceItem
+            key={item.id}
+            showIcon={false}
+            name={item.name}
+            description={item.description}
+            targetId={item.id}
+            onDelete={onRemoveKnowledge}
+          />
+        ))
+      ) : (
+        <div className={cx(styles.empty)}>暂无已选知识库</div>
+      )}
+    </div>
+  </div>
+);
+
+export default KnowledgeTabPanel;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/ModelTabPanel.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/ModelTabPanel.tsx
@@ -1,0 +1,93 @@
+/**
+ * 数据权限弹窗 —「模型」Tab 面板
+ *
+ * 功能：双栏布局；左侧为系统模型列表（可勾选加入权限），右侧为当前角色/用户组已选模型。
+ * 数据与请求由父组件 DataPermissionModal 维护，本组件仅负责展示与交互回调。
+ *
+ * @see DataPermissionModal
+ */
+import Loading from '@/components/custom/Loading';
+import type { ModelConfigDto } from '@/types/interfaces/systemManage';
+import classNames from 'classnames';
+import React from 'react';
+import ResourceItem from '../components/ResourceItem';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+
+/** 模型 Tab：列表数据、选中态与增删回调均由父组件注入 */
+export interface ModelTabPanelProps {
+  /** 模型列表加载中 */
+  modelLoading: boolean;
+  /** 左侧可选模型（来自系统模型接口） */
+  modelList?: ModelConfigDto[];
+  /** 已选模型 id 列表，用于左侧 ResourceItem 的 isAdded */
+  selectedModelIds: number[];
+  /** 右侧已选模型详情列表 */
+  selectedModelList: ModelConfigDto[];
+  /** 将模型加入已选（左侧「添加」） */
+  onToggleModel: (modelId: number) => void;
+  /** 从已选移除（右侧「删除」） */
+  onRemoveModel: (modelId: number) => void;
+}
+
+const ModelTabPanel: React.FC<ModelTabPanelProps> = ({
+  modelLoading,
+  modelList,
+  selectedModelIds,
+  selectedModelList,
+  onToggleModel,
+  onRemoveModel,
+}) => (
+  <div className={cx('flex', 'h-full')}>
+    {/* 左侧：可选模型（纵向滚动） */}
+    <div
+      className={cx(
+        'flex',
+        'flex-col',
+        'h-full',
+        'flex-1',
+        'overflow-y',
+        styles.leftList,
+      )}
+    >
+      {modelLoading && !modelList?.length ? (
+        <div className={cx('h-full', 'flex', 'items-center', 'content-center')}>
+          <Loading />
+        </div>
+      ) : (
+        modelList?.map((item) => (
+          <ResourceItem
+            key={item.id}
+            showIcon={false}
+            name={item.name}
+            description={item.description}
+            targetId={item.id}
+            onAdd={onToggleModel}
+            isAdded={selectedModelIds.includes(item.id)}
+          />
+        ))
+      )}
+    </div>
+    <div className={cx(styles.rightSeparator)} />
+    {/* 右侧：已选模型 */}
+    <div className={cx(styles.rightList, 'flex-1')}>
+      {selectedModelList.length ? (
+        selectedModelList.map((item) => (
+          <ResourceItem
+            key={item.id}
+            showIcon={false}
+            name={item.name}
+            description={item.description}
+            targetId={item.id}
+            onDelete={onRemoveModel}
+          />
+        ))
+      ) : (
+        <div className={cx(styles.empty)}>暂无已选模型</div>
+      )}
+    </div>
+  </div>
+);
+
+export default ModelTabPanel;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/PageTabPanel.tsx
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/PageTabPanel.tsx
@@ -1,0 +1,146 @@
+/**
+ * 数据权限弹窗 —「网页应用」Tab 面板
+ *
+ * 功能：与智能体 Tab 结构相同；左侧为网页应用类型广场列表（无限滚动），右侧为已选网页应用详情。
+ * 列表项主键在左侧为 targetId，右侧列表项为 devAgentId。
+ *
+ * @see DataPermissionModal
+ */
+import InfiniteScrollDiv from '@/components/custom/InfiniteScrollDiv';
+import Loading from '@/components/custom/Loading';
+import type { CustomPageDto } from '@/types/interfaces/pageDev';
+import type { SquarePublishedItemInfo } from '@/types/interfaces/square';
+import { Input } from 'antd';
+import classNames from 'classnames';
+import React, { RefObject } from 'react';
+import ResourceItem from '../components/ResourceItem';
+import styles from '../index.less';
+
+const cx = classNames.bind(styles);
+
+/** 网页应用 Tab：搜索、分页列表与选中列表由父组件管理 */
+export interface PageTabPanelProps {
+  /** 搜索框受控值 */
+  pageSearchKw: string;
+  onPageSearchKwChange: (v: string) => void;
+  /** 搜索第一页，keyword 为当前关键词 */
+  onPageSearch: (value: string) => void;
+  /** 左侧列表滚动容器，搜索时滚回顶部 */
+  pageListScrollRef: RefObject<HTMLDivElement>;
+  pageLoading: boolean;
+  pageList: SquarePublishedItemInfo[];
+  pageHasMore: boolean;
+  /** 触底加载下一页 */
+  onLoadMorePage: () => void;
+  /** 已选网页应用 id（与左侧 targetId 对应） */
+  selectedPageAgentIds: number[];
+  selectedPageList: CustomPageDto[];
+  /** 加入已选 */
+  onTogglePage: (targetId: number) => void;
+  /** 右侧删除使用 devAgentId */
+  onRemovePage: (devAgentId: number) => void;
+}
+
+const PageTabPanel: React.FC<PageTabPanelProps> = ({
+  pageSearchKw,
+  onPageSearchKwChange,
+  onPageSearch,
+  pageListScrollRef,
+  pageLoading,
+  pageList,
+  pageHasMore,
+  onLoadMorePage,
+  selectedPageAgentIds,
+  selectedPageList,
+  onTogglePage,
+  onRemovePage,
+}) => (
+  <div className={cx('flex', 'h-full')}>
+    {/* 左侧：搜索 + 网页应用列表（无限滚动，scrollTarget: page-list-scroll） */}
+    <div
+      className={cx(
+        'flex',
+        'flex-col',
+        'h-full',
+        'flex-1',
+        'overflow-hide',
+        styles.leftList,
+      )}
+    >
+      <Input.Search
+        key="pageSearch"
+        placeholder="搜索网页应用"
+        allowClear
+        className={cx(styles.searchInput)}
+        value={pageSearchKw}
+        onChange={(e) => onPageSearchKwChange(e.target.value)}
+        onSearch={(value) => {
+          onPageSearchKwChange(value);
+          if (pageListScrollRef.current) {
+            pageListScrollRef.current.scrollTo({
+              top: 0,
+              behavior: 'smooth',
+            });
+          }
+          onPageSearch(value);
+        }}
+      />
+      <div
+        ref={pageListScrollRef}
+        id="page-list-scroll"
+        className={cx('flex-1', 'overflow-y', 'h-full')}
+      >
+        {pageLoading && !pageList?.length ? (
+          <div
+            className={cx('h-full', 'flex', 'items-center', 'content-center')}
+          >
+            <Loading />
+          </div>
+        ) : (
+          <InfiniteScrollDiv
+            scrollableTarget="page-list-scroll"
+            list={pageList}
+            hasMore={pageHasMore}
+            onScroll={() => {
+              if (!pageLoading && pageHasMore) {
+                onLoadMorePage();
+              }
+            }}
+          >
+            {pageList?.map((item) => (
+              <ResourceItem
+                key={item.targetId}
+                icon={item.coverImg || item.icon}
+                name={item.name}
+                description={item.description}
+                targetId={item.targetId}
+                onAdd={onTogglePage}
+                isAdded={selectedPageAgentIds.includes(item.targetId)}
+              />
+            ))}
+          </InfiniteScrollDiv>
+        )}
+      </div>
+    </div>
+    <div className={cx(styles.rightSeparator)} />
+    {/* 右侧：已选网页应用 */}
+    <div className={cx(styles.rightList, 'flex-1')}>
+      {selectedPageList.length ? (
+        selectedPageList.map((item) => (
+          <ResourceItem
+            key={item.devAgentId}
+            icon={item.coverImg || item.icon}
+            name={item.name}
+            description={item.description}
+            targetId={item.devAgentId}
+            onDelete={onRemovePage}
+          />
+        ))
+      ) : (
+        <div className={cx(styles.empty)}>暂无已选网页应用</div>
+      )}
+    </div>
+  </div>
+);
+
+export default PageTabPanel;

--- a/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/index.ts
+++ b/src/pages/SystemManagement/MenuPermission/components/DataPermissionModal/tabPanels/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 数据权限弹窗各 Tab 内容面板统一出口，供 DataPermissionModal 按需引用。
+ */
+export { default as AgentTabPanel } from './AgentTabPanel';
+export { default as ApiPermissionTabPanel } from './ApiPermissionTabPanel';
+export { default as DeveloperPermissionFormTab } from './DeveloperPermissionFormTab';
+export { default as KnowledgeTabPanel } from './KnowledgeTabPanel';
+export { default as ModelTabPanel } from './ModelTabPanel';
+export { default as PageTabPanel } from './PageTabPanel';

--- a/src/pages/SystemManagement/MenuPermission/types/role-manage.ts
+++ b/src/pages/SystemManagement/MenuPermission/types/role-manage.ts
@@ -164,6 +164,16 @@ export interface UserInfo {
   avatar: string;
 }
 
+// 开放API权限配置
+export interface OpenApiConfigInfo {
+  /*开放api key */
+  key: string;
+  /*接口调用频率限制，每分钟调用次数 */
+  rpm: number;
+  /*接口调用频率限制，每天调用次数 */
+  rpd: number;
+}
+
 // 数据权限
 export interface DataPermission {
   /*模型ID列表，全部模型传[-1]，未选中任何模型不传或传空 */
@@ -177,6 +187,12 @@ export interface DataPermission {
 
   /*可访问的智能体id列表，null或空表示不限制 */
   agentIds?: number[];
+
+  /*有权限访问的知识库id列表 */
+  knowledgeIds?: number[];
+
+  /*开放API权限配置 */
+  openApiConfigs?: OpenApiConfigInfo[];
 
   /*可访问的应用页面id列表，null或空表示不限制 */
   pageAgentIds?: number[];

--- a/src/pages/SystemManagement/MenuPermission/types/user-group-manage.ts
+++ b/src/pages/SystemManagement/MenuPermission/types/user-group-manage.ts
@@ -42,8 +42,6 @@ export interface UserGroupInfo {
   source: UserGroupSourceEnum;
   /** 状态,1:启用 0:禁用 */
   status: UserGroupStatusEnum;
-  /** 最大用户数，0表示不限制 */
-  maxUserCount: number;
   /** 数据模型ID列表，全部模型传[0],未选中任何模型不传值 */
   modelIds: number[];
   // token限制
@@ -79,8 +77,6 @@ export interface AddUserGroupParams {
   description?: string;
   /* 状态,1:启用 0:禁用 */
   status?: UserGroupStatusEnum;
-  /** 最大用户数，0表示不限制 */
-  maxUserCount?: number;
   /** 数据模型ID列表，全部模型传[0],未选中任何模型不传值 */
   modelIds?: number[];
   // token限制

--- a/src/pages/UserManage/components/DataPermissionModal/components/UserOpenApiPermissionPanel/index.less
+++ b/src/pages/UserManage/components/DataPermissionModal/components/UserOpenApiPermissionPanel/index.less
@@ -1,0 +1,76 @@
+@import '@/styles/token';
+
+/**
+ * 覆盖 antd Tree 内部类名必须用 :global，且建议写成 `:global(.ant-xxx)`，
+ * 避免 `.local { :global { .ant-xxx { } } }` 在 css-loader 下把内层选择器误当作局部类名哈希化，
+ * 导致页面上真实的 `.ant-tree-*` 匹配不到。
+ * 选择器会编译为：`.api-permission-tree_哈希 .ant-tree-...`（仅作用于本面板内的树）。
+ */
+.api-permission-tree {
+  min-width: 0;
+
+  :global(.ant-tree-list-holder-inner .ant-tree-treenode) {
+    align-items: center;
+  }
+
+  :global(.ant-tree-node-content-wrapper) {
+    overflow: hidden;
+    flex: 1;
+    min-width: 0;
+  }
+
+  :global(.ant-tree-title) {
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
+  }
+}
+
+// API 权限树节点标题（只读展示 RPM/RPD）
+.openApiTreeTitleRow {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  gap: 12px;
+  justify-content: space-between;
+  height: 26px;
+
+  .openApiTreeTitleLeft {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow: hidden;
+
+    .openApiTreeTitleName {
+      flex: 0 1 auto;
+      max-width: 60%;
+    }
+
+    .openApiTreeTitlePath {
+      flex: 1 1 auto;
+      min-width: 0;
+      font-size: @fontSizeSm;
+      color: @colorTextSecondary;
+    }
+  }
+
+  .openApiTreeTitleControls {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+}
+
+/* 与系统管理端 ApiPermissionTabPanel 中 InputNumber 的 className 一致，供 CSS Modules 导出 */
+.font-12 {
+  font-size: @fontSizeSm;
+  color: @colorTextSecondary;
+}
+
+.input-number {
+  width: 72px;
+}

--- a/src/pages/UserManage/components/DataPermissionModal/components/UserOpenApiPermissionPanel/index.tsx
+++ b/src/pages/UserManage/components/DataPermissionModal/components/UserOpenApiPermissionPanel/index.tsx
@@ -1,0 +1,142 @@
+/**
+ * 用户数据权限弹窗 — API 权限 Tab（只读）
+ *
+ * 树结构、字段与系统管理端 ApiPermissionTabPanel 一致；勾选与 RPM/RPD 由接口返回的 openApiConfigs 决定，不可编辑。
+ */
+import Loading from '@/components/custom/Loading';
+import type { OpenApiConfigInfo } from '@/pages/SystemManagement/MenuPermission/types/role-manage';
+import type { OpenApiDefinition } from '@/types/interfaces/account';
+import { Empty, InputNumber, Tree, Typography } from 'antd';
+import classNames from 'classnames';
+import React, { useCallback, useMemo } from 'react';
+import styles from './index.less';
+
+const cx = classNames.bind(styles);
+const { Text } = Typography;
+
+/** 为整棵树禁用勾选交互，仅展示 checkedKeys 对应的选中态 */
+function withTreeNodeCheckboxDisabled(nodes: OpenApiDefinition[]): any[] {
+  return (nodes ?? []).map((node) => ({
+    ...node,
+    disableCheckbox: true,
+    apiList: node.apiList?.length
+      ? withTreeNodeCheckboxDisabled(node.apiList)
+      : undefined,
+  }));
+}
+
+export interface UserOpenApiPermissionReadonlyTabProps {
+  openApiListLoading: boolean;
+  openApiTreeData: OpenApiDefinition[];
+  /** 来自用户数据权限接口的 openApiConfigs，决定勾选与 RPM/RPD 展示 */
+  openApiConfigs: OpenApiConfigInfo[];
+}
+
+/** 用户数据API权限弹窗 — API 权限 Tab */
+const UserOpenApiPermissionPanel: React.FC<
+  UserOpenApiPermissionReadonlyTabProps
+> = ({ openApiListLoading, openApiTreeData, openApiConfigs }) => {
+  const treeData = useMemo(
+    () => withTreeNodeCheckboxDisabled(openApiTreeData),
+    [openApiTreeData],
+  );
+
+  const checkedKeys = useMemo(
+    () => openApiConfigs.map((c) => c.key),
+    [openApiConfigs],
+  );
+
+  const configByKey = useMemo(() => {
+    const m = new Map<string, OpenApiConfigInfo>();
+    openApiConfigs.forEach((c) => m.set(c.key, c));
+    return m;
+  }, [openApiConfigs]);
+
+  // 树节点标题渲染
+  const titleRender = useCallback(
+    (node: OpenApiDefinition) => {
+      const isLeaf = !node.apiList?.length;
+      const cfg = configByKey.get(node.key);
+      return (
+        <div className={styles.openApiTreeTitleRow}>
+          <div className={styles.openApiTreeTitleLeft}>
+            <span
+              className={cx(styles.openApiTreeTitleName, 'text-ellipsis')}
+              title={node.name}
+            >
+              {node.name}
+            </span>
+            {node.path ? (
+              <span
+                className={cx(styles.openApiTreeTitlePath, 'text-ellipsis')}
+                title={node.path}
+              >
+                {node.path}
+              </span>
+            ) : null}
+          </div>
+          {isLeaf && cfg ? (
+            <div
+              className={styles.openApiTreeTitleControls}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Text className={styles['font-12']}>每分钟调用次数</Text>
+              <InputNumber
+                size="small"
+                min={-1}
+                disabled
+                className={styles['input-number']}
+                value={cfg.rpm}
+              />
+              <Text className={styles['font-12']}>每天调用次数</Text>
+              <InputNumber
+                size="small"
+                min={-1}
+                disabled
+                className={styles['input-number']}
+                value={cfg.rpd}
+              />
+            </div>
+          ) : null}
+        </div>
+      );
+    },
+    [configByKey],
+  );
+
+  return (
+    <div
+      className={cx('h-full', 'overflow-hide', styles['api-permission-tree'])}
+    >
+      {openApiListLoading ? (
+        <div className={cx('h-full', 'flex', 'items-center', 'content-center')}>
+          <Loading />
+        </div>
+      ) : (
+        <div className={cx('h-full', 'overflow-y', 'py-16')}>
+          {treeData?.length > 0 ? (
+            <Tree
+              checkable
+              checkStrictly={false}
+              defaultExpandAll
+              checkedKeys={checkedKeys}
+              selectable={false}
+              treeData={treeData}
+              fieldNames={{ title: 'name', key: 'key', children: 'apiList' }}
+              titleRender={(node) => titleRender(node as OpenApiDefinition)}
+              blockNode
+            />
+          ) : (
+            <div
+              className={cx('flex', 'items-center', 'content-center', 'h-full')}
+            >
+              <Empty description="暂无 API 权限配置" />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserOpenApiPermissionPanel;

--- a/src/pages/UserManage/components/DataPermissionModal/index.less
+++ b/src/pages/UserManage/components/DataPermissionModal/index.less
@@ -21,6 +21,8 @@
     flex: 1;
     height: 400px;
     overflow-y: auto;
+    overflow-x: hidden;
+    min-width: 0;
   }
 }
 

--- a/src/pages/UserManage/components/DataPermissionModal/index.tsx
+++ b/src/pages/UserManage/components/DataPermissionModal/index.tsx
@@ -6,7 +6,10 @@ import {
 import { apiSystemModelList } from '@/services/systemManage';
 import { AgentConfigInfo } from '@/types/interfaces/agent';
 import { CustomPageDto } from '@/types/interfaces/pageDev';
-import type { ModelConfigDto } from '@/types/interfaces/systemManage';
+import type {
+  KnowledgeInfoById,
+  ModelConfigDto,
+} from '@/types/interfaces/systemManage';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Col, Empty, Form, InputNumber, Modal, Row, Tabs } from 'antd';
 import classNames from 'classnames';
@@ -14,6 +17,7 @@ import React, { useEffect, useState } from 'react';
 import { useRequest } from 'umi';
 import {
   apiSystemResourceAgentListByIds,
+  apiSystemResourceKnowledgeListByIds,
   apiSystemResourcePageListByIds,
   apiSystemUserDataPermission,
   UserDataPermission,
@@ -47,20 +51,35 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
   const [form] = Form.useForm();
   // 当前激活的tab
   const [activeTab, setActiveTab] = useState<DataPermissionTabKey>('model');
+
+  // ============================= 模型 =============================
+  // 存储查询到的数据权限中的 modelIds，用于处理异步加载问题
+  const [fetchedModelIds, setFetchedModelIds] = useState<number[] | null>(null);
+
+  // 已选中的模型列表（通过ID列表过滤）
+  const [filteredModelList, setFilteredModelList] = useState<ModelConfigDto[]>(
+    [],
+  );
+
+  // ============================= 智能体 =============================
   // 智能体列表
   const [agentList, setAgentList] = useState<AgentConfigInfo[]>([]);
-  // 应用页面列表
-  const [pageList, setPageList] = useState<CustomPageDto[]>([]);
   // 选中的智能体ID列表
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
+
+  // ============================= 应用页面 =============================
+  // 应用页面列表
+  const [pageList, setPageList] = useState<CustomPageDto[]>([]);
   // 选中的应用页面关联的agentId列表（此处应该是页面的devAgentId字段值列表）
   const [selectedPageAgentIds, setSelectedPageAgentIds] = useState<number[]>(
     [],
   );
-  // 存储查询到的数据权限中的 modelIds，用于处理异步加载问题
-  const [fetchedModelIds, setFetchedModelIds] = useState<number[] | null>(null);
 
-  const [filteredModelList, setFilteredModelList] = useState<ModelConfigDto[]>(
+  // ============================= 知识库 =============================
+  // 知识库列表
+  const [knowledgeList, setKnowledgeList] = useState<KnowledgeInfoById[]>([]);
+  // 选中的知识库ID列表
+  const [selectedKnowledgeIds, setSelectedKnowledgeIds] = useState<number[]>(
     [],
   );
 
@@ -101,6 +120,8 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         setFetchedModelIds(result.modelIds || null);
         setSelectedAgentIds(result.agentIds || []);
         setSelectedPageAgentIds(result.pageAgentIds || []);
+        // 知识库ID列表
+        setSelectedKnowledgeIds(result?.knowledgeIds || []);
       },
     });
 
@@ -125,6 +146,16 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       },
     },
   );
+
+  // ======================================= 知识库 =======================================
+  // 根据ID列表查询知识库列表
+  const { loading: knowledgeLoading, run: runGetKnowledgeListByIds } =
+    useRequest(apiSystemResourceKnowledgeListByIds, {
+      manual: true,
+      onSuccess: (result: KnowledgeInfoById[]) => {
+        setKnowledgeList(result || []);
+      },
+    });
 
   // 当弹窗打开时，加载数据
   useEffect(() => {
@@ -160,6 +191,12 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       setAgentList([]);
       setPageList([]);
       setActiveTab('model');
+
+      // ======================================= 知识库 =======================================
+      // 知识库列表
+      setKnowledgeList([]);
+      // 选中的知识库ID列表
+      setSelectedKnowledgeIds([]);
     }
   }, [open, userId]);
 
@@ -190,9 +227,6 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         runGetAgentListByIds({
           agentIds: selectedAgentIds,
         });
-      } else {
-        // 如果没有权限，清空列表
-        setAgentList([]);
       }
     } else if (tabKey === 'page') {
       if (selectedPageAgentIds.length > 0) {
@@ -200,52 +234,43 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         runGetPageListByIds({
           agentIds: selectedPageAgentIds,
         });
-      } else {
-        // 如果没有权限，清空列表
-        setPageList([]);
+      }
+    } else if (tabKey === 'knowledge') {
+      if (selectedKnowledgeIds.length > 0) {
+        // 切换到知识库 tab 时，根据权限 ID 列表查询知识库数据
+        runGetKnowledgeListByIds({
+          knowledgeIds: selectedKnowledgeIds,
+        });
       }
     }
   };
 
-  // 智能体列表（直接使用查询结果，因为接口已经根据 ID 列表过滤）
-  const filteredAgentList = agentList;
-
-  // 应用页面列表（直接使用查询结果，因为接口已经根据 ID 列表过滤）
-  const filteredPageList = pageList;
-
   // 检查是否有数据
   const hasModelData = filteredModelList.length > 0;
-  const hasAgentData = filteredAgentList.length > 0;
-  const hasPageData = filteredPageList.length > 0;
+  const hasAgentData = agentList.length > 0;
+  const hasPageData = pageList.length > 0;
 
   // 渲染 Tab 内容
   const renderTabContent = () => {
     switch (activeTab) {
       case 'model':
-        return hasModelData ? (
+        return (modelLoading || dataPermissionLoading) &&
+          !filteredModelList?.length ? (
+          <div
+            className={cx('h-full', 'flex', 'items-center', 'content-center')}
+          >
+            <Loading />
+          </div>
+        ) : hasModelData ? (
           <div className={cx('flex-1', 'overflow-y', 'h-full')}>
-            {(modelLoading || dataPermissionLoading) &&
-            !filteredModelList?.length ? (
-              <div
-                className={cx(
-                  'h-full',
-                  'flex',
-                  'items-center',
-                  'content-center',
-                )}
-              >
-                <Loading />
-              </div>
-            ) : (
-              filteredModelList?.map((item: ModelConfigDto) => (
-                <ResourceItem
-                  key={item.id}
-                  showIcon={false}
-                  name={item.name}
-                  description={item.description}
-                />
-              ))
-            )}
+            {filteredModelList?.map((item: ModelConfigDto) => (
+              <ResourceItem
+                key={item.id}
+                showIcon={false}
+                name={item.name}
+                description={item.description}
+              />
+            ))}
           </div>
         ) : (
           <div
@@ -255,7 +280,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           </div>
         );
       case 'agent':
-        return agentLoading && !filteredAgentList?.length ? (
+        return agentLoading && !agentList?.length ? (
           <div
             className={cx('h-full', 'flex', 'items-center', 'content-center')}
           >
@@ -263,7 +288,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           </div>
         ) : hasAgentData ? (
           <div className={cx('flex-1', 'overflow-y', 'h-full')}>
-            {filteredAgentList.map((item) => (
+            {agentList.map((item) => (
               <ResourceItem
                 key={item.id}
                 icon={item.icon}
@@ -280,7 +305,7 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           </div>
         );
       case 'page':
-        return pageLoading && !filteredPageList?.length ? (
+        return pageLoading && !pageList?.length ? (
           <div
             className={cx('h-full', 'flex', 'items-center', 'content-center')}
           >
@@ -288,10 +313,35 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
           </div>
         ) : hasPageData ? (
           <div className={cx('flex-1', 'overflow-y', 'h-full')}>
-            {filteredPageList.map((item) => (
+            {pageList.map((item) => (
               <ResourceItem
                 key={item.devAgentId}
                 icon={item.coverImg || item.icon}
+                name={item.name}
+                description={item.description}
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className={cx('flex', 'items-center', 'content-center', 'h-full')}
+          >
+            <Empty description="暂无数据" />
+          </div>
+        );
+      case 'knowledge':
+        return knowledgeLoading && !knowledgeList?.length ? (
+          <div
+            className={cx('h-full', 'flex', 'items-center', 'content-center')}
+          >
+            <Loading />
+          </div>
+        ) : knowledgeList?.length > 0 ? (
+          <div className={cx('flex-1', 'overflow-y', 'h-full')}>
+            {knowledgeList.map((item) => (
+              <ResourceItem
+                key={item.id}
+                icon={item.icon}
                 name={item.name}
                 description={item.description}
               />

--- a/src/pages/UserManage/components/DataPermissionModal/index.tsx
+++ b/src/pages/UserManage/components/DataPermissionModal/index.tsx
@@ -3,7 +3,13 @@ import {
   DATA_PERMISSION_TAB_ITEMS,
   DataPermissionTabKey,
 } from '@/pages/SystemManagement/MenuPermission/components/DataPermissionModal';
+import type { OpenApiConfigInfo } from '@/pages/SystemManagement/MenuPermission/types/role-manage';
+import {
+  apiGetOpenApiList,
+  OpenApiPermissionTargetTypeEnum,
+} from '@/services/account';
 import { apiSystemModelList } from '@/services/systemManage';
+import type { OpenApiDefinition } from '@/types/interfaces/account';
 import { AgentConfigInfo } from '@/types/interfaces/agent';
 import { CustomPageDto } from '@/types/interfaces/pageDev';
 import type {
@@ -13,7 +19,7 @@ import type {
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Col, Empty, Form, InputNumber, Modal, Row, Tabs } from 'antd';
 import classNames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRequest } from 'umi';
 import {
   apiSystemResourceAgentListByIds,
@@ -23,6 +29,7 @@ import {
   UserDataPermission,
 } from '../../user-manage';
 import ResourceItem from './components/ResourceItem';
+import UserOpenApiPermissionPanel from './components/UserOpenApiPermissionPanel';
 import styles from './index.less';
 
 const cx = classNames.bind(styles);
@@ -83,6 +90,15 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     [],
   );
 
+  // API 权限：用户数据权限接口返回的勾选与限流配置
+  const [userOpenApiConfigs, setUserOpenApiConfigs] = useState<
+    OpenApiConfigInfo[]
+  >([]);
+  const [openApiTreeData, setOpenApiTreeData] = useState<OpenApiDefinition[]>(
+    [],
+  );
+  const [openApiListLoading, setOpenApiListLoading] = useState(false);
+
   // 模型列表
   const {
     data: modelList,
@@ -122,8 +138,26 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
         setSelectedPageAgentIds(result.pageAgentIds || []);
         // 知识库ID列表
         setSelectedKnowledgeIds(result?.knowledgeIds || []);
+        // API 权限
+        setUserOpenApiConfigs(result.openApiConfigs || []);
       },
     });
+
+  /** 加载开放 API 树（与查看用户 API 权限一致，目标类型为 User） */
+  const loadOpenApiTree = useCallback(async () => {
+    setOpenApiListLoading(true);
+    try {
+      const res = await apiGetOpenApiList(OpenApiPermissionTargetTypeEnum.User);
+      if (res.success && res.data) {
+        setOpenApiTreeData(res.data);
+      }
+    } catch (e) {
+      console.error(e);
+      setOpenApiTreeData([]);
+    } finally {
+      setOpenApiListLoading(false);
+    }
+  }, []);
 
   // 根据ID列表查询智能体
   const { loading: agentLoading, run: runGetAgentListByIds } = useRequest(
@@ -197,6 +231,10 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
       setKnowledgeList([]);
       // 选中的知识库ID列表
       setSelectedKnowledgeIds([]);
+
+      // ======================================= API 权限 =======================================
+      setUserOpenApiConfigs([]);
+      setOpenApiTreeData([]);
     }
   }, [open, userId]);
 
@@ -220,28 +258,36 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
     const tabKey = key as DataPermissionTabKey;
     setActiveTab(tabKey);
 
-    // 只针对智能体和应用页面 tab 加载数据
-    if (tabKey === 'agent') {
-      if (selectedAgentIds.length > 0) {
-        // 切换到智能体 tab 时，根据权限 ID 列表查询智能体数据
-        runGetAgentListByIds({
-          agentIds: selectedAgentIds,
-        });
-      }
-    } else if (tabKey === 'page') {
-      if (selectedPageAgentIds.length > 0) {
-        // 切换到应用页面 tab 时，根据权限 ID 列表查询应用页面数据
-        runGetPageListByIds({
-          agentIds: selectedPageAgentIds,
-        });
-      }
-    } else if (tabKey === 'knowledge') {
-      if (selectedKnowledgeIds.length > 0) {
-        // 切换到知识库 tab 时，根据权限 ID 列表查询知识库数据
-        runGetKnowledgeListByIds({
-          knowledgeIds: selectedKnowledgeIds,
-        });
-      }
+    // 按需加载各 Tab 数据
+    switch (tabKey) {
+      case 'agent':
+        if (selectedAgentIds.length > 0) {
+          runGetAgentListByIds({
+            agentIds: selectedAgentIds,
+          });
+        }
+        break;
+      case 'page':
+        if (selectedPageAgentIds.length > 0) {
+          runGetPageListByIds({
+            agentIds: selectedPageAgentIds,
+          });
+        }
+        break;
+      case 'knowledge':
+        if (selectedKnowledgeIds.length > 0) {
+          runGetKnowledgeListByIds({
+            knowledgeIds: selectedKnowledgeIds,
+          });
+        }
+        break;
+      case 'apiPermission':
+        if (openApiTreeData.length === 0 && !openApiListLoading) {
+          loadOpenApiTree();
+        }
+        break;
+      default:
+        break;
     }
   };
 
@@ -529,6 +575,14 @@ const DataPermissionModal: React.FC<DataPermissionModalProps> = ({
               </Row>
             </Form>
           </div>
+        );
+      case 'apiPermission':
+        return (
+          <UserOpenApiPermissionPanel
+            openApiListLoading={openApiListLoading}
+            openApiTreeData={openApiTreeData}
+            openApiConfigs={userOpenApiConfigs}
+          />
         );
       default:
         return null;

--- a/src/pages/UserManage/user-manage.ts
+++ b/src/pages/UserManage/user-manage.ts
@@ -2,6 +2,7 @@ import { AgentConfigInfo } from '@/types/interfaces/agent';
 import { RoleInfo } from '@/types/interfaces/conversationInfo';
 import { CustomPageDto } from '@/types/interfaces/pageDev';
 import { RequestResponse } from '@/types/interfaces/request';
+import type { KnowledgeInfoById } from '@/types/interfaces/systemManage';
 import { request } from 'umi';
 import { MenuNodeInfo } from '../SystemManagement/MenuPermission/types/menu-manage';
 import { DataPermission } from '../SystemManagement/MenuPermission/types/role-manage';
@@ -96,6 +97,16 @@ export async function apiSystemResourcePageListByIds(data: {
   agentIds: number[];
 }): Promise<RequestResponse<CustomPageDto[]>> {
   return request(`/api/system/resource/page/list-by-ids`, {
+    method: 'POST',
+    data,
+  });
+}
+
+// 根据id列表查询知识库列表（数据权限回显）
+export async function apiSystemResourceKnowledgeListByIds(data: {
+  knowledgeIds: number[];
+}): Promise<RequestResponse<KnowledgeInfoById[]>> {
+  return request(`/api/system/resource/knowledge/list-by-ids`, {
     method: 'POST',
     data,
   });

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -226,12 +226,31 @@ export async function apiApiKeyStats(
 }
 
 /**
- * 获取 API 权限项列表
+ * 获取用户有权限的API列表
  */
 export async function apiGetOpenApiDefinitions(): Promise<
   RequestResponse<OpenApiDefinition[]>
 > {
   return request('/api/user/api-key/open-api-definitions', {
     method: 'GET',
+  });
+}
+
+// 开放API权限目标类型
+export enum OpenApiPermissionTargetTypeEnum {
+  User = 1,
+  Role = 2,
+  Group = 3,
+}
+
+/**
+ * 查询开放API列表
+ */
+export async function apiGetOpenApiList(
+  targetType: OpenApiPermissionTargetTypeEnum,
+): Promise<RequestResponse<OpenApiDefinition[]>> {
+  return request('/api/system/open-api/list', {
+    method: 'GET',
+    params: { targetType },
   });
 }

--- a/src/services/systemManage.ts
+++ b/src/services/systemManage.ts
@@ -266,6 +266,16 @@ export async function apiSystemResourceKnowledgeDelete(data: {
   });
 }
 
+// 更新知识库管控状态
+export async function apiSystemResourceKnowledgeAccessControl(
+  id: number,
+  status: number,
+): Promise<RequestResponse<null>> {
+  return request(`/api/system/resource/knowledge/access/${id}/${status}`, {
+    method: 'POST',
+  });
+}
+
 // 查询数据表列表
 export async function apiSystemResourceDataTableList(
   data: SystemDataTableListParams,

--- a/src/types/interfaces/systemManage.ts
+++ b/src/types/interfaces/systemManage.ts
@@ -5,6 +5,10 @@ import {
   UserStatusEnum,
 } from '@/types/enums/systemManage';
 import { PublishStatusEnum } from '../enums/common';
+import {
+  KnowledgeDataTypeEnum,
+  KnowledgePubStatusEnum,
+} from '../enums/library';
 import { PluginPublishScopeEnum } from '../enums/plugin';
 import { TaskInfo } from './library';
 
@@ -452,6 +456,47 @@ export type SystemWebappPage = SystemPageResult<SystemWebappInfo>;
 
 // 知识库信息
 export type SystemKnowledgeInfo = SystemResourceInfo;
+
+// 根据id列表查询知识库详情
+export interface KnowledgeInfoById {
+  // 主键id
+  id: number;
+  // 知识库名称
+  name: string;
+  // 知识库描述
+  description: string;
+  // 知识状态,可用值:Waiting,Published
+  pubStatus: KnowledgePubStatusEnum;
+  // 数据类型,默认文本,1:文本;2:表格
+  dataType: KnowledgeDataTypeEnum;
+  // 知识库的嵌入模型ID
+  embeddingModelId: number;
+  // 知识库的生成Q&A模型ID
+  chatModelId: number;
+  spaceId: number;
+  // 图标的url地址
+  icon: string;
+  // 创建时间
+  created: string;
+  // 创建人id
+  creatorId: number;
+  // 创建人
+  creatorName: string;
+  // 	创建人昵称
+  creatorNickName: string;
+  // 头像
+  creatorAvatar: string;
+  // 更新时间
+  modified: string;
+  // 最后修改人id
+  modifiedId: number;
+  // 最后修改人
+  modifiedName: string;
+  // 工作流id
+  workflowId?: string;
+  // 是否受后台权限控制，0 不受，1 受
+  accessControl: AccessControlEnum;
+}
 
 // 查询知识库列表参数
 export interface SystemKnowledgeListParams extends SystemPaginationParams {

--- a/src/types/interfaces/systemManage.ts
+++ b/src/types/interfaces/systemManage.ts
@@ -463,6 +463,8 @@ export interface SystemKnowledgeListParams extends SystemPaginationParams {
   spaceId?: number;
   /** 创建人名称 */
   creatorName?: string;
+  /** 管控状态 */
+  accessControl?: AccessControlEnum;
 }
 
 // 知识库列表分页响应


### PR DESCRIPTION
1、在系统设置-菜单权限中对角色和用户组设置数据权限弹窗中，新增对知识库和API权限tab的设置；
2、在知识库列表中新增管控列表，并对受管控的知识库新增授权功能，可通过授权弹窗直接设置当前知识库还有权限的角色或用户组；
3、智能体和网页应用列表中，对未受管控，且未发布到系统广场的智能体，禁止切换管控按钮；
4、用户管理页中对查询数据权限弹窗，新增知识库和API权限查看
5、刷新文件树频率节流时长改为5000ms