### PR TITLE
fix(Square): 修复广场智能体查询接口，需要添加目标子类型为ChatBot

### DIFF
--- a/src/pages/Square/index.tsx
+++ b/src/pages/Square/index.tsx
@@ -221,6 +221,8 @@ const Square: React.FC = () => {
     // 智能体
     if (categoryTypeRef.current === SquareAgentTypeEnum.Agent) {
       data.targetType = AgentComponentTypeEnum.Agent;
+      // 目标子类型（查询智能体时，需要设置目标子类型, ChatBot查询的智能体包含了对话型智能体和通用型智能体）
+      data.targetSubType = 'ChatBot';
     }
 
     // 网页应用


### PR DESCRIPTION
添加目标子类型设置以支持智能体查询

- 在 Square 组件中，新增目标子类型设置，确保在查询智能体时正确指定目标子类型为 'ChatBot'。
- 该改动提升了智能体查询的准确性和功能完整性。