### PR TITLE
Feat pujing

### DIFF
--- a/src/components/FileTreeView/index.tsx
+++ b/src/components/FileTreeView/index.tsx
@@ -433,6 +433,12 @@ const FileTreeView = forwardRef<FileTreeViewRef, FileTreeViewProps>(
               return;
             }
 
+            // 先切到当前文件并清空内容，避免异步返回前继续显示上一个文件内容
+            setSelectedFileNode({
+              ...fileNode,
+              content: '',
+            });
+
             // 获取文件内容并更新文件树
             const newFileContent = await fetchFileContentUpdateFiles(
               fileProxyUrl,
@@ -1522,6 +1528,7 @@ const FileTreeView = forwardRef<FileTreeViewRef, FileTreeViewProps>(
       // 代码文件：使用代码查看器
       return (
         <CodeViewer
+          key={`code-viewer-${selectedFileId}`}
           isDynamicTheme={isDynamicTheme}
           fileId={selectedFileId}
           fileName={fileName}

--- a/src/components/business-component/ConversationDetails/index.tsx
+++ b/src/components/business-component/ConversationDetails/index.tsx
@@ -384,16 +384,6 @@ const ConversationDetails: React.FC<ConversationDetailsProps> = ({
         {/* 页面顶部: 标题区域 */}
         <header className={cx(styles['title-box'])}>
           <div className={cx(styles['title-container'])}>
-            {/* 左侧标题 */}
-            <Typography.Title
-              level={5}
-              className={cx(styles.title)}
-              ellipsis={{ rows: 1, expandable: false, symbol: '...' }}
-            >
-              {cachedAgentName ? `和${cachedAgentName}开始会话` : ''}
-            </Typography.Title>
-
-            {/* 右侧按钮区域 */}
             <div className={cx('flex', 'items-center', 'gap-4')}>
               {/* 应用智能体模式下，显示内容导航按钮 */}
               <ConditionRender
@@ -411,7 +401,18 @@ const ConversationDetails: React.FC<ConversationDetailsProps> = ({
                   }
                 />
               </ConditionRender>
+              {/* 左侧标题 */}
+              <Typography.Title
+                level={5}
+                className={cx(styles.title)}
+                ellipsis={{ rows: 1, expandable: false, symbol: '...' }}
+              >
+                {cachedAgentName ? `和${cachedAgentName}开始会话` : ''}
+              </Typography.Title>
+            </div>
 
+            {/* 右侧按钮区域 */}
+            <div className={cx('flex', 'items-center', 'gap-4')}>
               {/* 这里放可以展开 AgentSidebar 的控制按钮 在AgentSidebar 展示的时候隐藏 反之显示 */}
               {!isAppSidebarMode && !isSidebarVisible && !isMobile && (
                 <TooltipIcon

--- a/src/constants/event.constants.tsx
+++ b/src/constants/event.constants.tsx
@@ -3,6 +3,5 @@ import { EventTypeEnum } from '@/types/enums/event';
 export const EVENT_TYPE: Record<string, EventTypeEnum> = {
   NewNotifyMessage: EventTypeEnum.NewNotifyMessage, // 新消息
   RefreshChatMessage: EventTypeEnum.RefreshChatMessage, // 刷新会话
-  RefreshFileList: EventTypeEnum.RefreshFileList, // 刷新文件列表
   ChatFinished: EventTypeEnum.ChatFinished, // 会话结束后，更新会话状态
 };

--- a/src/constants/space.constants.tsx
+++ b/src/constants/space.constants.tsx
@@ -149,6 +149,8 @@ export const APPLICATION_MORE_ACTION = [
   { type: ApplicationMoreActionEnum.Copy_To_Space, label: '复制到空间' },
   { type: ApplicationMoreActionEnum.Move, label: '迁移' },
   { type: ApplicationMoreActionEnum.Temporary_Session, label: '临时会话' },
+  // 独立会话（已发布的智能体可独立会话）
+  { type: ApplicationMoreActionEnum.Independent_Session, label: '独立会话' },
   { type: ApplicationMoreActionEnum.API_Key, label: 'API Key' },
   { type: ApplicationMoreActionEnum.Export_Config, label: '导出配置' },
   { type: ApplicationMoreActionEnum.Log, label: '日志' },

--- a/src/models/conversationInfo.ts
+++ b/src/models/conversationInfo.ts
@@ -3,7 +3,6 @@ import {
   CONVERSATION_CONNECTION_URL,
   MESSAGE_PAGE_SIZE,
 } from '@/constants/common.constants';
-import { EVENT_TYPE } from '@/constants/event.constants';
 import { ACCESS_TOKEN } from '@/constants/home.constants';
 import { getCustomBlock } from '@/plugins/ds-markdown-process';
 import {
@@ -69,7 +68,6 @@ import {
 import { extractTaskResult } from '@/utils';
 import { modalConfirm } from '@/utils/ant-custom';
 import { isEmptyObject } from '@/utils/common';
-import eventBus from '@/utils/eventBus';
 import { createSSEConnection } from '@/utils/fetchEventSourceConversationInfo';
 import {
   perfTracker,
@@ -360,22 +358,25 @@ export default () => {
   }, []);
 
   // 打开预览视图
-  const openPreviewView = useCallback(async (cId: number) => {
-    // 停止保活
-    stopKeepalivePodPolling();
+  const openPreviewView = useCallback(
+    async (cId: number) => {
+      // 停止保活
+      stopKeepalivePodPolling();
 
-    // 检查是否需要刷新文件列表
-    // 只有在模式发生变化（从 desktop 切换到 preview）或首次打开文件树时才刷新
-    const needRefresh =
-      viewModeRef.current !== 'preview' || !isFileTreeVisibleRef.current;
+      // 检查是否需要刷新文件列表
+      // 只有在模式发生变化（从 desktop 切换到 preview）或首次打开文件树时才刷新
+      const needRefresh =
+        viewModeRef.current !== 'preview' || !isFileTreeVisibleRef.current;
 
-    // 打开预览视图或远程桌面视图时修改状态值
-    openPreviewChangeState('preview');
-    // 只在需要时触发文件列表刷新事件
-    if (needRefresh) {
-      eventBus.emit(EVENT_TYPE.RefreshFileList, cId);
-    }
-  }, []);
+      // 打开预览视图或远程桌面视图时修改状态值
+      openPreviewChangeState('preview');
+      // 只在需要时触发文件列表刷新事件
+      if (needRefresh) {
+        handleRefreshFileList(cId);
+      }
+    },
+    [handleRefreshFileList],
+  );
 
   // 滚动到底部
   const messageViewScrollToBottom = () => {

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -628,20 +628,11 @@ const Chat: React.FC = () => {
     // conversationInfo 会无缝接管加载显示，不会出现 AgentChatEmpty 闪现
     setClearLoading(false);
 
-    // 用于绑定刷新文件列表事件的回调函数
-    const refreshFileList = () => {
-      handleRefreshFileList(id);
-    };
-
     // 监听新消息事件
     eventBus.on(EVENT_TYPE.RefreshChatMessage, handleConversationUpdate);
-    // 订阅文件列表刷新事件
-    eventBus.on(EVENT_TYPE.RefreshFileList, refreshFileList);
 
     return () => {
       eventBus.off(EVENT_TYPE.RefreshChatMessage, handleConversationUpdate);
-      // 组件卸载时取消订阅
-      eventBus.off(EVENT_TYPE.RefreshFileList, refreshFileList);
 
       // 组件卸载时重置全局会话状态，防止污染其他页面
       resetInit();

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1077,12 +1077,6 @@ const Chat: React.FC = () => {
         {/* 页面顶部: 标题区域 */}
         <header className={cx(styles['title-box'])}>
           <div className={cx(styles['title-container'])}>
-            <DropdownChangeName
-              agentId={agentId}
-              conversationInfo={conversationInfo}
-              setConversationInfo={setConversationInfo}
-              isAppSidebarMode={isAppSidebarMode}
-            />
             <div className={cx('flex', 'items-center', 'gap-4')}>
               {/* 应用智能体模式下，显示内容导航按钮 */}
               <ConditionRender
@@ -1113,7 +1107,15 @@ const Chat: React.FC = () => {
                   }
                 />
               </ConditionRender>
+              <DropdownChangeName
+                agentId={agentId}
+                conversationInfo={conversationInfo}
+                setConversationInfo={setConversationInfo}
+                isAppSidebarMode={isAppSidebarMode}
+              />
+            </div>
 
+            <div className={cx('flex', 'items-center', 'gap-4')}>
               {/* 这里放可以展开 AgentSidebar 的控制按钮 在AgentSidebar 展示的时候隐藏 反之显示 */}
               {/* 当文件树显示时，也显示这个按钮，用于关闭文件树并打开 AgentSidebar */}
               {!isAppSidebarMode && !isSidebarVisible && !isMobile && (

--- a/src/pages/EditAgent/index.tsx
+++ b/src/pages/EditAgent/index.tsx
@@ -8,7 +8,6 @@ import type { PromptVariable } from '@/components/TiptapVariableInput/types';
 import { transformToPromptVariables } from '@/components/TiptapVariableInput/utils/variableTransform';
 import VersionHistory from '@/components/VersionHistory';
 import { SUCCESS_CODE } from '@/constants/codes.constants';
-import { EVENT_TYPE } from '@/constants/event.constants';
 import useUnifiedTheme from '@/hooks/useUnifiedTheme';
 import AnalyzeStatistics from '@/pages/SpaceDevelop/AnalyzeStatistics';
 import CreateTempChatModal from '@/pages/SpaceDevelop/CreateTempChatModal';
@@ -58,7 +57,6 @@ import {
 import { checkFileSizeExceedLimit } from '@/utils';
 import { modalConfirm } from '@/utils/ant-custom';
 import { addBaseTarget } from '@/utils/common';
-import eventBus from '@/utils/eventBus';
 import {
   exportConfigFile,
   exportWholeProjectZip,
@@ -520,23 +518,6 @@ const EditAgent: React.FC = () => {
     } as AgentConfigInfo;
     setAgentConfigInfo(_agentConfigInfo);
   };
-
-  useEffect(() => {
-    if (!devConversationId) {
-      return;
-    }
-    // 订阅文件列表刷新事件
-    eventBus.on(EVENT_TYPE.RefreshFileList, () =>
-      handleRefreshFileList(devConversationId),
-    );
-
-    return () => {
-      // 组件卸载时取消订阅
-      eventBus.off(EVENT_TYPE.RefreshFileList, () =>
-        handleRefreshFileList(devConversationId),
-      );
-    };
-  }, [devConversationId]);
 
   // 新建文件（空内容）、文件夹
   const handleCreateFileNode = async (

--- a/src/pages/OpenApp/BaseTemplate/index.less
+++ b/src/pages/OpenApp/BaseTemplate/index.less
@@ -9,7 +9,7 @@
 .agentSidebarContainer {
   width: 280px;
   height: 100%;
-  padding: 14px @paddingSm;
+  padding: @paddingXs @paddingSm;
   border-right: @colorBorderSecondary 1px solid;
   background-color: @colorBgContainerDisabled;
   display: flex;
@@ -28,6 +28,7 @@
 }
 
 .sidebarTop {
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -47,8 +48,8 @@
   }
 
   .collapseBtn {
-    width: 32px;
-    height: 32px;
+    width: 16px;
+    height: 16px;
     margin-left: auto;
     border-radius: 50%;
   }

--- a/src/pages/OpenApp/BaseTemplate/index.less
+++ b/src/pages/OpenApp/BaseTemplate/index.less
@@ -97,7 +97,7 @@
 
 // 历史会话标题
 .history-title {
-  padding: @paddingXs 0;
+  padding: @paddingXs 0 @paddingXs @paddingSm;
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
@@ -126,6 +126,10 @@
       color: @navSecondMenuTextSecondary;
     }
   }
+}
+
+.history-list {
+  padding-left: 28px;
 }
 
 // 底部渐变

--- a/src/pages/OpenApp/BaseTemplate/index.tsx
+++ b/src/pages/OpenApp/BaseTemplate/index.tsx
@@ -292,7 +292,7 @@ const BaseTemplate: React.FC = () => {
               {/* 历史会话列表 */}
               <div
                 ref={historyListRef}
-                className={cx('flex-1', 'overflow-y')}
+                className={cx('flex-1', 'overflow-y', 'scroll-container')}
                 onScroll={handleHistoryScroll}
               >
                 {conversationList?.length

--- a/src/pages/OpenApp/BaseTemplate/index.tsx
+++ b/src/pages/OpenApp/BaseTemplate/index.tsx
@@ -277,7 +277,10 @@ const BaseTemplate: React.FC = () => {
           ) : (
             <>
               <div className={cx(styles['history-title'])}>
-                <span className={cx(styles.title)}>历史会话</span>
+                <span className={cx(styles.title)}>
+                  <SvgIcon name="icons-nav-time" style={{ fontSize: 16 }} />
+                  历史会话
+                </span>
 
                 <ConditionRender condition={conversationList?.length}>
                   <span
@@ -292,7 +295,12 @@ const BaseTemplate: React.FC = () => {
               {/* 历史会话列表 */}
               <div
                 ref={historyListRef}
-                className={cx('flex-1', 'overflow-y', 'scroll-container')}
+                className={cx(
+                  'flex-1',
+                  'overflow-y',
+                  'scroll-container',
+                  styles['history-list'],
+                )}
                 onScroll={handleHistoryScroll}
               >
                 {conversationList?.length

--- a/src/pages/SpaceDevelop/ApplicationItem/index.tsx
+++ b/src/pages/SpaceDevelop/ApplicationItem/index.tsx
@@ -65,6 +65,9 @@ const ApplicationItem: React.FC<ApplicationItemProps> = ({
             hasPermission(PermissionsEnum.TempChat) &&
             agentConfigInfo.type !== AgentTypeEnum.TaskAgent
           );
+        // 独立会话
+        case ApplicationMoreActionEnum.Independent_Session:
+          return agentConfigInfo?.publishStatus === PublishStatusEnum.Published;
         // 迁移
         case ApplicationMoreActionEnum.Move:
           // 迁移操作：仅创建者和管理员展示

--- a/src/pages/SpaceDevelop/index.tsx
+++ b/src/pages/SpaceDevelop/index.tsx
@@ -184,10 +184,6 @@ const SpaceDevelop: React.FC = () => {
       setOpenMove(false);
       // 目标空间ID
       const targetSpaceId = params[1];
-      // 如果目标空间ID和当前空间ID相同, 则重新查询当前空间智能体列表
-      // if (targetSpaceId === spaceId) {
-      //   run(spaceId);
-      // }
       // 跳转
       jumpToAgent(targetSpaceId, data);
     },
@@ -375,6 +371,19 @@ const SpaceDevelop: React.FC = () => {
       case ApplicationMoreActionEnum.Temporary_Session:
         setOpenTempChat(true);
         setCurrentAgentInfo(agentInfo);
+        break;
+      // 独立会话
+      case ApplicationMoreActionEnum.Independent_Session:
+        // 之所以使用try catch，是因为navigator.clipboard.writeText在某些浏览器或NuwaClaw中可能不支持
+        try {
+          // 这里实现复制路径到浏览器地址栏
+          const path = `${window.location.origin}/app/details/${agentInfo.id}`;
+          navigator.clipboard.writeText(path);
+          message.success('已复制独立会话路径');
+        } catch (error) {
+          console.error('复制独立会话路径失败:', error);
+          message.error('复制独立会话路径失败');
+        }
         break;
       // API Key
       case ApplicationMoreActionEnum.API_Key:

--- a/src/types/enums/event.ts
+++ b/src/types/enums/event.ts
@@ -3,8 +3,6 @@ export enum EventTypeEnum {
   NewNotifyMessage = 'new_notify_message',
   // 会话消息列表需要刷新
   RefreshChatMessage = 'refresh_chat_message',
-  // 文件列表需要刷新
-  RefreshFileList = 'refresh_file_list',
   // 会话结束后，更新会话状态
   ChatFinished = 'chat_finished',
 }

--- a/src/types/enums/space.ts
+++ b/src/types/enums/space.ts
@@ -61,6 +61,8 @@ export enum ApplicationMoreActionEnum {
   Move = 'Move',
   // 临时会话
   Temporary_Session = 'Temporary_Session',
+  // 独立会话
+  Independent_Session = 'Independent_Session',
   // API Key
   API_Key = 'API_Key',
   // 导出配置


### PR DESCRIPTION
1、为已发布的智能体卡片新增独立会话复制链接操作；
2、优化应用菜单栏以及智能体header部分、聊天页header样式（主要是在隐藏应用侧边栏时，将展开以及新建会话图标放在左边）；
3、取消智能体聊天页、智能体编排页中对文件树刷新的eventBus.on监听事件，并在对应事件中直接调用方法刷新文件树；
4、修复txt文件切换时，从有内容的文件切换到空文件时，显示内容未改变的bug；