### PR TITLE
fix(XProTable): 修复多语言刷新与 LightFilter 文案

### DIFF
--- a/src/components/ChatView/RunOver/index.tsx
+++ b/src/components/ChatView/RunOver/index.tsx
@@ -131,8 +131,8 @@ const RunOver: React.FC<RunOverProps> = ({
             {showStatusDesc && lastProcessInfo && (
               <span className={cx(styles['status-name'])}>
                 {lastProcessInfo.status === ProcessingEnum.EXECUTING
-                  ? dict('PC.Components.RunOver.calling') + ' '
-                  : dict('PC.Components.RunOver.called', '')}
+                  ? `${dict('PC.Components.RunOver.calling', '')} `
+                  : `${dict('PC.Components.RunOver.called', '')} `}
                 {lastProcessInfo.name}
               </span>
             )}

--- a/src/components/ProComponents/XModalForm/index.tsx
+++ b/src/components/ProComponents/XModalForm/index.tsx
@@ -1,9 +1,11 @@
+import { dict } from '@/services/i18nRuntime';
 import { ModalForm, ModalFormProps } from '@ant-design/pro-components';
 import React from 'react';
 
 function XModalForm<T = Record<string, any>>({
   children,
   requiredMark,
+  submitter,
   ...restProps
 }: ModalFormProps<T>) {
   // 默认 requiredMark 渲染函数，将必填标识放在后方
@@ -20,6 +22,13 @@ function XModalForm<T = Record<string, any>>({
   return (
     <ModalForm<T>
       requiredMark={requiredMark ?? defaultRequiredMark}
+      submitter={{
+        searchConfig: {
+          submitText: dict('PC.Common.Global.confirm'),
+          resetText: dict('PC.Common.Global.cancel'),
+        },
+        ...submitter,
+      }}
       {...restProps}
     >
       {children}

--- a/src/components/ProComponents/XProTable/index.tsx
+++ b/src/components/ProComponents/XProTable/index.tsx
@@ -1,15 +1,17 @@
 import { COMMON_PRO_TABLE_PROPS } from '@/constants/dataTable.constants';
 import { useTableAutoHeight } from '@/hooks/useTableAutoHeight';
-import { dict } from '@/services/i18nRuntime';
+import { dict, getCurrentLang } from '@/services/i18nRuntime';
+import { getUmiLocaleKey } from '@/utils/i18nAdapters';
 import type {
   ActionType,
   FormInstance,
   ParamsType,
   ProTableProps,
 } from '@ant-design/pro-components';
-import { ProTable } from '@ant-design/pro-components';
+import { ProConfigProvider, ProTable } from '@ant-design/pro-components';
 import { Button } from 'antd';
 import { useMemo, useRef } from 'react';
+import { useIntl } from 'umi';
 
 /**
  * XProTable - 预配置的 ProTable 封装组件
@@ -50,8 +52,14 @@ function XProTable<
     showIndex = false,
     ...restProps
   } = props;
+  const intl = useIntl();
   const tableRef = useRef<HTMLDivElement>(null);
   const scrollY = useTableAutoHeight(tableRef, fullHeight, scrollYOffset);
+  /**
+   * 当前语言采用 Umi 的响应式 locale（优先），并回退到运行时语言快照。
+   * 这样在语言切换时组件会自动 re-render，确保 memo 内文案可重新计算。
+   */
+  const currentLang = intl.locale || getCurrentLang();
 
   // 合并 scroll 配置
   // 如果开启了 fullHeight，则使用计算出的 scrollY
@@ -97,7 +105,7 @@ function XProTable<
     }
 
     return cols;
-  }, [restProps.columns, showIndex]);
+  }, [restProps.columns, showIndex, currentLang]);
 
   // 合并 toolBarRender，添加查询/重置按钮
   const mergedToolBarRender = useMemo(() => {
@@ -136,14 +144,28 @@ function XProTable<
         </Button>,
       ];
     };
-  }, [restProps.toolBarRender, formRef, actionRef, onReset, showQueryButtons]);
+  }, [
+    restProps.toolBarRender,
+    formRef,
+    actionRef,
+    onReset,
+    showQueryButtons,
+    currentLang,
+  ]);
 
   // 合并 search 配置
   const searchConfig = useMemo(() => {
     if (restProps.search === false) return false;
     const baseSearch =
       typeof restProps.search === 'object' ? restProps.search : {};
-    const commonSearch = (COMMON_PRO_TABLE_PROPS.search as any) || {};
+    const commonSearch = {
+      ...(COMMON_PRO_TABLE_PROPS.search as any),
+      /**
+       * 避免使用模块初始化时的静态文案，改为运行时读取，确保语言切换后可见最新翻译。
+       */
+      searchText: dict('PC.Constants.DataTable.search'),
+      resetText: dict('PC.Constants.DataTable.reset'),
+    };
 
     const merged = {
       ...commonSearch,
@@ -157,7 +179,69 @@ function XProTable<
     }
 
     return merged;
-  }, [restProps.search]);
+  }, [restProps.search, currentLang]);
+
+  /**
+   * 分页文案同样采用运行时翻译，避免 COMMON_PRO_TABLE_PROPS 的静态快照问题。
+   */
+  const paginationConfig = useMemo(() => {
+    if (restProps.pagination === false) return false;
+    const basePagination =
+      typeof restProps.pagination === 'object' ? restProps.pagination : {};
+    const commonPagination =
+      (COMMON_PRO_TABLE_PROPS.pagination as Record<string, any>) || {};
+
+    return {
+      ...commonPagination,
+      ...basePagination,
+      showTotal:
+        basePagination.showTotal ||
+        ((total: number) =>
+          `${dict('PC.Constants.DataTable.totalPrefix')} ${total} ${dict(
+            'PC.Constants.DataTable.totalSuffix',
+          )}`),
+      locale: {
+        ...(commonPagination.locale || {}),
+        ...(basePagination.locale || {}),
+        items_per_page:
+          basePagination.locale?.items_per_page ||
+          dict('PC.Constants.DataTable.itemsPerPage'),
+      },
+    };
+  }, [restProps.pagination, currentLang]);
+
+  /**
+   * ProComponents 的国际化依赖 locale 标识。
+   * 使用统一适配层输出的 Umi locale key（如 en-US / zh-CN），
+   * 避免 lower-case 语言码导致 Pro 无法命中内置语言包而回退默认中文。
+   */
+  const proIntl = useMemo(
+    () => ({
+      locale: getUmiLocaleKey(currentLang),
+      /**
+       * ProTable 在运行期会直接调用 intl.getMessage。
+       * 若未提供该函数会抛出 "intl.getMessage is not a function"。
+       * 这里提供一个稳定实现：优先映射到项目 dict，其余回退 defaultMessage。
+       */
+      getMessage: (id: string, defaultMessage: string) => {
+        switch (id) {
+          case 'form.lightFilter.clear':
+            return dict('PC.Constants.DataTable.reset');
+          case 'form.lightFilter.confirm':
+            return dict('PC.Common.Global.confirm');
+          case 'tableForm.submit':
+            return dict('PC.Common.Global.confirm');
+          case 'tableForm.reset':
+            return dict('PC.Constants.DataTable.reset');
+          case 'tableForm.search':
+            return dict('PC.Constants.DataTable.search');
+          default:
+            return defaultMessage || id;
+        }
+      },
+    }),
+    [currentLang],
+  );
 
   return (
     <div ref={tableRef} style={{ width: '100%' }} className="x-pro-table">
@@ -194,16 +278,19 @@ function XProTable<
       `,
         }}
       />
-      <ProTable<DataType, Params, ValueType>
-        {...COMMON_PRO_TABLE_PROPS}
-        {...restProps}
-        formRef={formRef}
-        actionRef={actionRef}
-        columns={mergedColumns}
-        toolBarRender={mergedToolBarRender}
-        search={searchConfig}
-        scroll={scroll}
-      />
+      <ProConfigProvider intl={proIntl as any}>
+        <ProTable<DataType, Params, ValueType>
+          {...COMMON_PRO_TABLE_PROPS}
+          {...restProps}
+          formRef={formRef}
+          actionRef={actionRef}
+          columns={mergedColumns}
+          toolBarRender={mergedToolBarRender}
+          search={searchConfig}
+          pagination={paginationConfig}
+          scroll={scroll}
+        />
+      </ProConfigProvider>
     </div>
   );
 }

--- a/src/locales/i18n/en-US.ts
+++ b/src/locales/i18n/en-US.ts
@@ -640,7 +640,7 @@ export const EN_US: SystemLangMap = {
   'PC.Components.RecommendList.pagePathConfigError': 'Page path configuration error',
   'PC.Components.RecommendList.pagePathParamError': 'Page path parameter configuration error',
   'PC.Components.RecommendList.pagePreview': 'Page Preview',
-  'PC.Components.RunOver.called': '{0} called',
+  'PC.Components.RunOver.called': '{0} Called',
   'PC.Components.RunOver.calling': 'Calling',
   'PC.Components.RunOver.runComplete': 'Run Complete',
   'PC.Components.RunOver.runError': 'Run Error',


### PR DESCRIPTION
## Summary
- 让 `XProTable` 的文案计算跟随 `umi` 语言切换响应式更新，避免切语言后列标题/按钮文案不刷新。
- 为 `ProConfigProvider` 补充稳定的 `intl.getMessage` 实现，修复 `intl.getMessage is not a function` 运行时错误。
- 补齐 LightFilter Popover（`ant-popover`）中的清除/确认等 Pro 内置文案映射，并统一分页与搜索文案的运行时翻译行为。

## Test plan
- [x] 切换 `zh-CN` / `en-US` 后，`XProTable` 序号列与工具栏按钮文案正确刷新。
- [x] 打开 LightFilter 下拉浮层，`清除/确认` 文案显示正确且不再出现未翻译。
- [x] 页面运行过程中不再出现 `Uncaught TypeError: intl.getMessage is not a function`。
- [x] 本地 `lint-staged` 与提交钩子通过。

Made with [Cursor](https://cursor.com)