### PR TITLE
feat(a11y): add axe audit baseline and shared UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.umi-production
 /.umi-test
 /dist
+/reports/a11y/*.json
 /.mfsu
 .swc
 /.idea

--- a/docs/ch/a11y-checklist.md
+++ b/docs/ch/a11y-checklist.md
@@ -1,0 +1,44 @@
+# 无障碍检查清单
+
+本项目为前端通用区域保留一套轻量级 WCAG 基线。
+
+## 本地审计
+
+运行生产构建下的 axe 快照：
+
+```bash
+pnpm install
+pnpm run audit:a11y
+```
+
+脚本会构建应用、本地托管 `dist`，扫描 `/login`、`/`、`/home`、`/square`，并把 JSON 报告写入 `reports/a11y/`。
+
+常用覆盖项：
+
+```bash
+A11Y_PAGES=/login,/home pnpm run audit:a11y
+A11Y_BASE_URL=http://localhost:3000 pnpm run audit:a11y
+A11Y_SKIP_BUILD=1 pnpm run audit:a11y
+A11Y_CHROME_PATH=/path/to/chrome pnpm run audit:a11y
+```
+
+## 组件规则
+
+- 优先使用原生 `button`、`a`、`input` 和表单控件，再考虑 ARIA。
+- 只有图标的按钮必须用 `aria-label` 提供可访问名称。
+- 自定义可点击容器必须同时支持鼠标和键盘激活。
+- 保留可见焦点态；不要在没有替代方案时移除 outline。
+- 图片需要有意义的 `alt`，装饰性图片使用 `alt=""`。
+- 新增通用 UI 组件时，尽量补充 axe smoke test。
+
+## PR 期望
+
+- 开 PR 前运行 `pnpm exec max lint`。
+- 修改 base/custom/layout 通用 UI 时，运行聚焦的 axe smoke test。
+- 如果 `audit:a11y` 发现问题，在 PR body 里附上报告摘要。
+
+## 故障排查
+
+如果 `audit:a11y` 在产出 axe JSON 前失败，并提示缺少 `chromedriver` 二进制文件，请在该环境中通过 `pnpm approve-builds` 允许 `chromedriver` 安装脚本，然后重新安装或重建依赖。
+
+如果提示找不到 Chrome 二进制文件，请安装 Chrome/Chromium，或把 `A11Y_CHROME_PATH` 指向浏览器可执行文件。

--- a/docs/en/a11y-checklist.md
+++ b/docs/en/a11y-checklist.md
@@ -1,0 +1,44 @@
+# Accessibility Checklist
+
+This project keeps a lightweight WCAG baseline for shared frontend surfaces.
+
+## Local Audit
+
+Run an axe snapshot against the production build:
+
+```bash
+pnpm install
+pnpm run audit:a11y
+```
+
+The script builds the app, serves `dist` locally, scans `/login`, `/`, `/home`, and `/square`, then writes a JSON report under `reports/a11y/`.
+
+Useful overrides:
+
+```bash
+A11Y_PAGES=/login,/home pnpm run audit:a11y
+A11Y_BASE_URL=http://localhost:3000 pnpm run audit:a11y
+A11Y_SKIP_BUILD=1 pnpm run audit:a11y
+A11Y_CHROME_PATH=/path/to/chrome pnpm run audit:a11y
+```
+
+## Component Rules
+
+- Prefer native `button`, `a`, `input`, and form controls before adding ARIA.
+- Icon-only buttons must have an accessible name with `aria-label`.
+- Custom clickable wrappers must support both pointer and keyboard activation.
+- Visible focus states must remain enabled; do not remove outlines without a replacement.
+- Images need useful `alt` text, or `alt=""` when the image is decorative.
+- New shared UI components should include an axe smoke test when practical.
+
+## PR Expectations
+
+- Run `pnpm exec max lint` before opening the PR.
+- Run the focused axe smoke test when touching shared base/custom/layout UI.
+- Include the generated report summary in the PR body if `audit:a11y` finds issues.
+
+## Troubleshooting
+
+If `audit:a11y` fails before producing axe JSON and mentions a missing `chromedriver` binary, allow the `chromedriver` install script with `pnpm approve-builds` in that environment, then reinstall or rebuild dependencies.
+
+If it cannot find a Chrome binary, install Chrome/Chromium or set `A11Y_CHROME_PATH` to the browser executable.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "Apache-2.0",
   "author": "Nuwax AI FE Team",
   "scripts": {
+    "audit:a11y": "node scripts/a11y-audit.js",
     "prebuild:dev": "node scripts/generate-version.js",
     "build:dev": "cross-env UMI_ENV=development max build",
     "build:m": "node scripts/download-mobile-build.js",
@@ -122,10 +123,12 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@axe-core/cli": "^4.11.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/clean-css": "^4.2.11",
+    "@types/jest-axe": "^3.5.9",
     "@types/lodash": "^4.17.16",
     "@types/prismjs": "^1.26.5",
     "@types/qs": "^6.14.0",
@@ -139,6 +142,7 @@
     "cross-env": "^7.0.3",
     "esbuild": "^0.27.0",
     "husky": "^9.1.7",
+    "jest-axe": "^10.0.0",
     "jsdom": "^27.3.0",
     "lint-staged": "^13.2.0",
     "prettier": "^2.8.7",

--- a/scripts/a11y-audit.js
+++ b/scripts/a11y-audit.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Runs an axe-core accessibility snapshot against production-like routes.
+ */
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const cwd = process.cwd();
+const distDir = path.resolve(cwd, 'dist');
+const reportDir = path.resolve(cwd, 'reports', 'a11y');
+const versionFile = path.resolve(cwd, 'src', 'constants', 'version.ts');
+const pnpmCommand = 'pnpm';
+const defaultPages = ['/login', '/', '/home', '/square'];
+
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+};
+
+const readOptionalFile = (filePath) => {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const restoreOptionalFile = (filePath, originalContent) => {
+  if (originalContent === null) {
+    fs.rmSync(filePath, { force: true });
+    return;
+  }
+  fs.writeFileSync(filePath, originalContent);
+};
+
+const quoteWindowsArg = (arg) => {
+  const value = String(arg);
+  return /[\s&()^|<>]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+};
+
+const run = (command, args, options = {}) =>
+  new Promise((resolve, reject) => {
+    const spawnCommand = process.platform === 'win32' ? 'cmd.exe' : command;
+    const spawnArgs =
+      process.platform === 'win32'
+        ? ['/d', '/c', [command, ...args.map(quoteWindowsArg)].join(' ')]
+        : args;
+    const child = spawn(spawnCommand, spawnArgs, {
+      cwd,
+      env: process.env,
+      shell: false,
+      stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    });
+    let stdout = '';
+    let stderr = '';
+
+    if (options.capture) {
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0 && !options.allowFailure) {
+        reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+        return;
+      }
+      resolve({ code, stdout, stderr });
+    });
+  });
+
+const createStaticServer = () => {
+  const indexPath = path.join(distDir, 'index.html');
+
+  return http.createServer((request, response) => {
+    const requestUrl = new URL(request.url || '/', 'http://127.0.0.1');
+    const safePath = decodeURIComponent(requestUrl.pathname).replace(
+      /^\/+/,
+      '',
+    );
+    const candidatePath = path.resolve(distDir, safePath);
+    const isInsideDist =
+      candidatePath === distDir ||
+      candidatePath.startsWith(`${distDir}${path.sep}`);
+    const filePath = isInsideDist ? candidatePath : indexPath;
+
+    const sendFile = (resolvedPath) => {
+      const extension = path.extname(resolvedPath);
+      response.setHeader(
+        'Content-Type',
+        mimeTypes[extension] || 'application/octet-stream',
+      );
+      fs.createReadStream(resolvedPath)
+        .on('error', () => {
+          response.writeHead(404);
+          response.end('Not found');
+        })
+        .pipe(response);
+    };
+
+    fs.stat(filePath, (error, stat) => {
+      if (!error && stat.isFile()) {
+        sendFile(filePath);
+        return;
+      }
+      sendFile(indexPath);
+    });
+  });
+};
+
+const listen = (server) =>
+  new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+
+const closeServer = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const parsePages = () => {
+  if (!process.env.A11Y_PAGES) {
+    return defaultPages;
+  }
+  return process.env.A11Y_PAGES.split(',')
+    .map((page) => page.trim())
+    .filter(Boolean);
+};
+
+const summarize = (axeResults) => {
+  const pages = Array.isArray(axeResults) ? axeResults : [axeResults];
+  const violations = pages.flatMap((page) =>
+    (page.violations || []).map((violation) => ({
+      id: violation.id,
+      impact: violation.impact,
+      nodes: violation.nodes?.length || 0,
+      url: page.url,
+    })),
+  );
+
+  return {
+    pages: pages.length,
+    violations: violations.length,
+    affectedNodes: violations.reduce(
+      (sum, violation) => sum + violation.nodes,
+      0,
+    ),
+    topViolations: violations.slice(0, 10),
+  };
+};
+
+const main = async () => {
+  const pages = parsePages();
+  const externalBaseUrl = process.env.A11Y_BASE_URL;
+  const shouldBuild = !externalBaseUrl && process.env.A11Y_SKIP_BUILD !== '1';
+  const originalVersionFile = readOptionalFile(versionFile);
+  let server;
+
+  try {
+    if (shouldBuild) {
+      await run(pnpmCommand, ['run', 'build:prod']);
+    }
+
+    const baseUrl =
+      externalBaseUrl || (await listen((server = createStaticServer())));
+    const urls = pages.map((page) => new URL(page, baseUrl).href);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const reportPath = path.join(reportDir, `axe-${timestamp}.json`);
+    const loadDelay = process.env.A11Y_LOAD_DELAY || '1500';
+    const timeout = process.env.A11Y_TIMEOUT || '90';
+    const tags = process.env.A11Y_TAGS || 'wcag2a,wcag2aa,best-practice';
+    const browserArgs = [
+      ...(process.env.A11Y_CHROME_PATH
+        ? ['--chrome-path', process.env.A11Y_CHROME_PATH]
+        : []),
+      ...(process.env.A11Y_CHROMEDRIVER_PATH
+        ? ['--chromedriver-path', process.env.A11Y_CHROMEDRIVER_PATH]
+        : []),
+      ...(process.env.A11Y_CHROME_OPTIONS
+        ? ['--chrome-options', process.env.A11Y_CHROME_OPTIONS]
+        : []),
+    ];
+
+    fs.mkdirSync(reportDir, { recursive: true });
+
+    const axeResult = await run(
+      pnpmCommand,
+      [
+        'exec',
+        'axe',
+        ...urls,
+        '--stdout',
+        '--exit',
+        '--tags',
+        tags,
+        '--load-delay',
+        loadDelay,
+        '--timeout',
+        timeout,
+        ...browserArgs,
+      ],
+      { allowFailure: true, capture: true },
+    );
+
+    let axeJson;
+    try {
+      axeJson = JSON.parse(axeResult.stdout);
+    } catch (error) {
+      const failureReport = {
+        generatedAt: new Date().toISOString(),
+        pages: urls,
+        error: 'Failed to parse axe JSON output.',
+        stdout: axeResult.stdout,
+        stderr: axeResult.stderr,
+      };
+      fs.writeFileSync(reportPath, JSON.stringify(failureReport, null, 2));
+      console.error(
+        `A11y audit failed before producing valid JSON: ${reportPath}`,
+      );
+      process.exitCode = axeResult.code || 1;
+      return;
+    }
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      pages: urls,
+      tags,
+      loadDelayMs: Number(loadDelay),
+      timeoutSeconds: Number(timeout),
+      summary: summarize(axeJson),
+      results: axeJson,
+    };
+
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    console.log(`A11y report written to ${path.relative(cwd, reportPath)}`);
+    console.log(
+      `Violations: ${report.summary.violations}; affected nodes: ${report.summary.affectedNodes}`,
+    );
+
+    process.exitCode = axeResult.code;
+  } finally {
+    if (server) {
+      await closeServer(server);
+    }
+    if (shouldBuild) {
+      restoreOptionalFile(versionFile, originalVersionFile);
+    }
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/components/base/ActionMenu/index.less
+++ b/src/components/base/ActionMenu/index.less
@@ -14,9 +14,8 @@
   border-radius: @borderRadius;
   background-color: @colorPrimaryBg;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   user-select: none;
-  outline: none;
 
   &:hover {
     background-color: @colorPrimaryBgHover;
@@ -30,9 +29,14 @@
     background-color: @colorPrimaryBgHover;
   }
 
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+  }
+
   .action-icon {
     color: inherit;
-    transition: all 0.2s ease;
+    transition: color 0.2s ease;
     // width: 16px;
     // height: 16px;
     display: flex;
@@ -44,7 +48,7 @@
     font-size: @fontSize;
     color: @colorText;
     white-space: nowrap;
-    transition: all 0.2s ease;
+    transition: color 0.2s ease;
   }
 
   // 更多按钮样式
@@ -53,7 +57,7 @@
       font-size: @fontSizeSm;
       color: @colorText;
       margin-left: @marginXxs;
-      transition: all 0.2s ease;
+      transition: color 0.2s ease;
     }
 
     &:hover .more-arrow {

--- a/src/components/base/ActionMenu/index.tsx
+++ b/src/components/base/ActionMenu/index.tsx
@@ -1,5 +1,6 @@
 import SvgIcon from '@/components/base/SvgIcon';
 import { dict } from '@/services/i18nRuntime';
+import { isKeyboardActivation } from '@/utils/a11y';
 import { DownOutlined } from '@ant-design/icons';
 import { Dropdown, theme } from 'antd';
 import classNames from 'classnames';
@@ -95,13 +96,15 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
         }
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && !action.disabled && !disabled) {
+        if (isKeyboardActivation(e) && !action.disabled && !disabled) {
+          e.preventDefault();
           action.onClick();
         }
       }}
-      tabIndex={0}
+      tabIndex={action.disabled || disabled ? -1 : 0}
       role="button"
       aria-label={action.title}
+      aria-disabled={action.disabled || disabled}
     >
       <SvgIcon
         name={action.icon}
@@ -176,10 +179,16 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
         >
           <div
             className={cx(styles['action-item'], styles['more-button'])}
-            tabIndex={0}
+            tabIndex={disabled ? -1 : 0}
             role="button"
             aria-label={moreText}
-            onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.click()}
+            aria-disabled={disabled}
+            onKeyDown={(e) => {
+              if (isKeyboardActivation(e) && !disabled) {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
             style={{
               marginLeft: normalizeGap,
             }}

--- a/src/components/base/CopyButton/index.less
+++ b/src/components/base/CopyButton/index.less
@@ -2,7 +2,11 @@
 @import '@/styles/token';
 
 .copy-btn {
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: @colorTextDescription;
+  font-family: inherit;
   font-size: @fontSizeSm;
   transition: color 0.2s ease-in-out;
   user-select: none;
@@ -14,6 +18,12 @@
   &.disabled {
     color: @colorTextDisabled;
     cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+    border-radius: @borderRadiusSm;
   }
 }
 

--- a/src/components/base/CopyButton/index.tsx
+++ b/src/components/base/CopyButton/index.tsx
@@ -58,6 +58,11 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   successMessage,
   errorMessage,
 }) => {
+  const accessibleLabel =
+    typeof children === 'string'
+      ? children
+      : tooltipText || dict('PC.Common.Global.copy');
+
   // 处理复制
   const handleCopy = async () => {
     try {
@@ -112,7 +117,8 @@ const CopyButton: React.FC<CopyButtonProps> = ({
   // 如果禁用，返回禁用状态的按钮
   if (disabled) {
     return (
-      <span
+      <button
+        type="button"
         className={cx(
           styles['copy-btn'],
           styles.disabled,
@@ -123,16 +129,19 @@ const CopyButton: React.FC<CopyButtonProps> = ({
         )}
         style={style}
         title={tooltipText}
+        aria-label={accessibleLabel}
+        disabled
       >
         {icon || defaultIcon}
         <span>{children}</span>
-      </span>
+      </button>
     );
   }
 
   // 可点击的复制按钮
   return (
-    <span
+    <button
+      type="button"
       className={cx(
         styles['copy-btn'],
         'flex',
@@ -142,11 +151,12 @@ const CopyButton: React.FC<CopyButtonProps> = ({
       )}
       style={style}
       title={tooltipText}
+      aria-label={accessibleLabel}
       onClick={handleCopy}
     >
       {icon || defaultIcon}
       <span>{children}</span>
-    </span>
+    </button>
   );
 };
 

--- a/src/components/base/CopyIconButton/index.tsx
+++ b/src/components/base/CopyIconButton/index.tsx
@@ -87,6 +87,7 @@ const CopyIconButton: React.FC<CopyIconButtonProps> = ({
         type={buttonType}
         size={buttonSize}
         icon={<CopyOutlined />}
+        aria-label={tooltipTitle}
         onClick={handleCopy}
         style={style}
         className={className}

--- a/src/components/base/DraggableTableRow/index.tsx
+++ b/src/components/base/DraggableTableRow/index.tsx
@@ -1,3 +1,4 @@
+import { dict } from '@/services/i18nRuntime';
 import { HolderOutlined } from '@ant-design/icons';
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
 import { useSortable } from '@dnd-kit/sortable';
@@ -25,6 +26,7 @@ export const DragHandle: React.FC = () => {
       type="text"
       size="small"
       icon={<HolderOutlined />}
+      aria-label={dict('PC.Pages.SystemConfigI18n.columnSort')}
       style={{ cursor: 'move' }}
       ref={setActivatorNodeRef}
       {...listeners}

--- a/src/components/base/MenuListItem/index.less
+++ b/src/components/base/MenuListItem/index.less
@@ -50,6 +50,12 @@
     }
   }
 
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+    border-radius: @borderRadius;
+  }
+
   .icon-box {
     font-size: 20px;
     border-radius: @borderRadiusSm;

--- a/src/components/base/MenuListItem/index.tsx
+++ b/src/components/base/MenuListItem/index.tsx
@@ -1,5 +1,6 @@
 import CustomPopover from '@/components/CustomPopover';
 import { dict } from '@/services/i18nRuntime';
+import { isKeyboardActivation } from '@/utils/a11y';
 import { EllipsisOutlined } from '@ant-design/icons';
 import classNames from 'classnames';
 import React, { useEffect, useMemo, useRef } from 'react';
@@ -56,6 +57,16 @@ const MenuListItem: React.FC<MenuListItemProps> = ({
       )}
       style={style}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (isKeyboardActivation(e)) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={name}
+      aria-current={isActive ? 'page' : undefined}
     >
       <span
         className={cx(

--- a/src/components/base/SecondMenuItem/index.less
+++ b/src/components/base/SecondMenuItem/index.less
@@ -62,6 +62,12 @@
     }
   }
 
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+    border-radius: @borderRadius;
+  }
+
   .title {
     font-size: @fontSize;
   }

--- a/src/components/base/SecondMenuItem/index.tsx
+++ b/src/components/base/SecondMenuItem/index.tsx
@@ -1,3 +1,4 @@
+import { isKeyboardActivation } from '@/utils/a11y';
 import { Typography } from 'antd';
 import classNames from 'classnames';
 import React from 'react';
@@ -37,7 +38,23 @@ const SecondMenuItem: React.FC<SecondMenuItemProps> = ({
         [styles.open]: isOpen,
       })}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (isKeyboardActivation(e)) {
+          e.preventDefault();
+          onClick();
+          return;
+        }
+        if (isDown && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
+          e.preventDefault();
+          onToggle?.();
+        }
+      }}
       style={style}
+      role="button"
+      tabIndex={0}
+      aria-label={name}
+      aria-current={isActive ? 'page' : undefined}
+      aria-expanded={isDown ? isOpen : undefined}
     >
       <span
         className={cx(
@@ -51,7 +68,7 @@ const SecondMenuItem: React.FC<SecondMenuItemProps> = ({
           icon?.includes('.png') ||
           icon?.includes('.jpg') ||
           icon?.includes('.jpeg') ? (
-            <img className={cx(styles['icon-image'])} src={icon} />
+            <img className={cx(styles['icon-image'])} src={icon} alt={name} />
           ) : (
             <SvgIcon name={icon} />
           )
@@ -66,6 +83,7 @@ const SecondMenuItem: React.FC<SecondMenuItemProps> = ({
         <SvgIcon
           name="icons-common-caret_down"
           className={cx(styles['icon-dropdown'])}
+          aria-hidden="true"
           onClick={(e) => {
             e.stopPropagation();
             onToggle?.();

--- a/src/components/custom/TooltipIcon/index.less
+++ b/src/components/custom/TooltipIcon/index.less
@@ -1,8 +1,15 @@
 @import '@/styles/color';
+@import '@/styles/token';
 
 .box {
   width: 26px;
   height: 26px;
   font-size: 14px;
   color: @GRAY32;
+
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+    border-radius: @borderRadiusSm;
+  }
 }

--- a/src/components/custom/TooltipIcon/index.tsx
+++ b/src/components/custom/TooltipIcon/index.tsx
@@ -1,6 +1,7 @@
 import SvgIcon from '@/components/base/SvgIcon';
 import { TooltipTitleTypeEnum } from '@/types/enums/common';
 import type { TooltipIconProps } from '@/types/interfaces/space';
+import { isKeyboardActivation } from '@/utils/a11y';
 import { theme, Tooltip } from 'antd';
 import classNames from 'classnames';
 import React from 'react';
@@ -16,12 +17,16 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({
   type = TooltipTitleTypeEnum.Blank,
   icon,
   title,
+  ariaLabel,
   placement,
   onClick,
 }) => {
   const bg =
     type === TooltipTitleTypeEnum.Blank ? 'tooltip-blank' : 'tooltip-white';
   const { token } = theme.useToken();
+  const accessibleLabel =
+    ariaLabel || (typeof title === 'string' ? title : undefined);
+
   return (
     <Tooltip title={title} classNames={{ root: bg }} placement={placement}>
       <span
@@ -35,6 +40,15 @@ const TooltipIcon: React.FC<TooltipIconProps> = ({
           className,
         )}
         onClick={onClick}
+        onKeyDown={(e) => {
+          if (onClick && isKeyboardActivation(e)) {
+            e.preventDefault();
+            e.currentTarget.click();
+          }
+        }}
+        role={onClick ? 'button' : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        aria-label={onClick ? accessibleLabel : undefined}
       >
         {/*默认加号（+）*/}
         {icon || (

--- a/src/layouts/DynamicMenusLayout/User/UserAvatar/index.less
+++ b/src/layouts/DynamicMenusLayout/User/UserAvatar/index.less
@@ -11,6 +11,11 @@
   box-sizing: content-box;
   border: @lineWidth solid @colorBorder;
 
+  &:focus-visible {
+    outline: @lineWidthBold solid @colorPrimary;
+    outline-offset: @paddingXxs;
+  }
+
   img {
     width: 100%;
     height: 100%;

--- a/src/layouts/DynamicMenusLayout/User/UserAvatar/index.tsx
+++ b/src/layouts/DynamicMenusLayout/User/UserAvatar/index.tsx
@@ -1,5 +1,7 @@
 import avatarImage from '@/assets/images/avatar.png';
+import { dict } from '@/services/i18nRuntime';
 import type { UserAvatarType } from '@/types/interfaces/layouts';
+import { isKeyboardActivation } from '@/utils/a11y';
 import classNames from 'classnames';
 import React from 'react';
 import styles from './index.less';
@@ -7,9 +9,23 @@ import styles from './index.less';
 const cx = classNames.bind(styles);
 
 const UserAvatar: React.FC<UserAvatarType> = ({ avatar, onClick }) => {
+  const avatarLabel = dict('PC.Components.Created.userAvatar');
+
   return (
-    <div className={cx('cursor-pointer', styles.user)} onClick={onClick}>
-      <img src={avatar || (avatarImage as string)} alt="" />
+    <div
+      className={cx('cursor-pointer', styles.user)}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (isKeyboardActivation(e)) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={avatarLabel}
+    >
+      <img src={avatar || (avatarImage as string)} alt={avatarLabel} />
     </div>
   );
 };

--- a/src/types/interfaces/space.ts
+++ b/src/types/interfaces/space.ts
@@ -57,6 +57,7 @@ export interface TooltipIconProps {
   className?: string;
   type?: TooltipTitleTypeEnum;
   title?: React.ReactNode;
+  ariaLabel?: string;
   icon?: React.ReactNode;
   placement?: TooltipPlacement;
   onClick?: MouseEventHandler<HTMLSpanElement>;

--- a/src/utils/a11y.ts
+++ b/src/utils/a11y.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared keyboard helpers for custom interactive wrappers.
+ */
+import type React from 'react';
+
+export const isKeyboardActivation = (event: React.KeyboardEvent<HTMLElement>) =>
+  event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar';

--- a/tests/a11y/base-components.test.tsx
+++ b/tests/a11y/base-components.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Axe smoke coverage for low-level shared UI components.
+ */
+import {
+  ActionMenu,
+  CopyButton,
+  CopyIconButton,
+  MenuListItem,
+  SecondMenuItem,
+} from '@/components/base';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+const assertNoViolations = async (element: HTMLElement) => {
+  const results = await axe(element);
+  expect(results.violations).toEqual([]);
+};
+
+describe('base component accessibility baseline', () => {
+  it('renders CopyButton without axe violations', async () => {
+    const { container } = render(<CopyButton text="hello">Copy</CopyButton>);
+    await assertNoViolations(container);
+  });
+
+  it('renders CopyIconButton without axe violations', async () => {
+    const { container } = render(<CopyIconButton text="hello" />);
+    await assertNoViolations(container);
+  });
+
+  it('renders ActionMenu without axe violations', async () => {
+    const { container } = render(
+      <ActionMenu
+        actions={[
+          {
+            key: 'copy',
+            icon: 'icons-chat-copy',
+            title: 'Copy',
+            onClick: vi.fn(),
+          },
+          {
+            key: 'delete',
+            icon: 'icons-common-delete',
+            title: 'Delete',
+            onClick: vi.fn(),
+          },
+        ]}
+      />,
+    );
+    await assertNoViolations(container);
+  });
+
+  it('renders MenuListItem without axe violations', async () => {
+    const { container } = render(
+      <MenuListItem
+        icon="icons-common-plus"
+        name="New Item"
+        onClick={vi.fn()}
+      />,
+    );
+    await assertNoViolations(container);
+  });
+
+  it('renders SecondMenuItem without axe violations', async () => {
+    const { container } = render(
+      <SecondMenuItem
+        icon="icons-common-plus"
+        name="Workspace"
+        onClick={vi.fn()}
+      />,
+    );
+    await assertNoViolations(container);
+  });
+});


### PR DESCRIPTION
## English

### Summary
Adds a lightweight accessibility baseline for shared frontend UI.

### Changes
- Added `scripts/a11y-audit.js` and `pnpm run audit:a11y` based on `@axe-core/cli`.
- Ignored generated reports under `reports/a11y/*.json`.
- Added `tests/a11y/base-components.test.tsx` with `jest-axe` smoke coverage for shared base components.
- Improved keyboard activation, focus-visible states, accessible names, and image alt text in shared base/custom/layout components.
- Added accessibility checklist docs in `docs/en/a11y-checklist.md` and `docs/ch/a11y-checklist.md`.

### Validation
- ✅ `pnpm exec max lint`
- ✅ `pnpm exec prettier --check <changed files>`
- ✅ `node scripts/check-hardcoded-i18n.js`
- ✅ `node --check scripts/a11y-audit.js`
- ⚠️ `pnpm exec vitest tests/a11y/base-components.test.tsx --run` is blocked by the repo's existing Vitest/Vite startup issue: `vite` does not export `./module-runner` for the current Vitest/Vite combination.
- ⚠️ `pnpm run audit:a11y` completed the production build, but the local axe browser step is blocked in this environment because Chrome binary is unavailable. The script now writes a JSON failure report and the docs include `chromedriver` / `A11Y_CHROME_PATH` guidance.

## 中文

### 摘要
为通用前端 UI 增加一套轻量级无障碍基线。

### 变更
- 新增 `scripts/a11y-audit.js` 和 `pnpm run audit:a11y`，基于 `@axe-core/cli`。
- 忽略生成的 `reports/a11y/*.json` 报告文件。
- 新增 `tests/a11y/base-components.test.tsx`，使用 `jest-axe` 为通用基础组件补充 smoke test。
- 修复一批 shared base/custom/layout 组件的键盘激活、focus-visible、可访问名称和图片 alt 问题。
- 新增 `docs/en/a11y-checklist.md` 与 `docs/ch/a11y-checklist.md`。

### 验证
- ✅ `pnpm exec max lint`
- ✅ `pnpm exec prettier --check <changed files>`
- ✅ `node scripts/check-hardcoded-i18n.js`
- ✅ `node --check scripts/a11y-audit.js`
- ⚠️ `pnpm exec vitest tests/a11y/base-components.test.tsx --run` 受仓库现有 Vitest/Vite 启动问题阻塞：当前环境下 `vite` 没有导出 `./module-runner`。
- ⚠️ `pnpm run audit:a11y` 的生产构建已成功，但本地 axe 浏览器步骤因当前环境缺少 Chrome binary 被阻塞；脚本已支持输出 JSON 失败报告，文档也补充了 `chromedriver` / `A11Y_CHROME_PATH` 说明。
