### PR TITLE
feat(security): unify user-content HTML rendering behind SafeHtml

### DIFF
--- a/docs/ch/security-content-rendering.md
+++ b/docs/ch/security-content-rendering.md
@@ -1,0 +1,66 @@
+<!--
+面向贡献者的 SafeHtml / DOMPurify 内容渲染说明。
+-->
+
+# 安全内容渲染
+
+## 目的
+
+`SafeHtml` 为非 Markdown 渲染路径提供统一的 HTML 安全边界。凡是前端需要渲染“不是硬编码可信常量”的 HTML，都应优先走这个组件或它的 `sanitizeHtml` 辅助方法。
+
+它基于 `dompurify`，默认做了比较保守的收口：
+
+- 去掉 `<script>` 和事件处理属性
+- 拦截 `javascript:` / `vbscript:` URL
+- 默认禁止 `data:` URL，只对图片 `src` 放行图片 MIME
+- 默认拦截 `iframe` 等高风险嵌入标签
+
+补充说明：`dompurify` 已自带 TypeScript 类型，因此不需要额外安装 `@types/dompurify`。
+
+## Profiles
+
+### `strict`
+
+适合短文本、标题、副标题、弹窗文案、管理端可配置但只需要少量内联格式的 HTML。
+
+### `markdown-output`
+
+适合已经生成好的富文本 HTML，例如段落、列表、标题、图片、表格、链接等。
+
+### `svg`
+
+只在确实需要渲染内联 SVG 片段时使用。这个 profile 应该保持少量使用，并且每次放开新标签或属性都要补针对性测试。
+
+## 示例
+
+```tsx
+import SafeHtml from '@/components/base/SafeHtml';
+
+<SafeHtml
+  as="div"
+  html={content}
+  profile="markdown-output"
+  allowedTags={['variable']}
+  allowedAttributes={['data-key']}
+/>;
+```
+
+## 如何选择
+
+- 默认先用 `strict`
+- 只有确实需要块级富文本时再切到 `markdown-output`
+- `allowedTags` / `allowedAttributes` 只用于很窄的例外场景，并在 PR 里说明原因
+- 新增用户内容 HTML 渲染入口时，不要绕过 `SafeHtml`
+
+## 如何申请新 Profile 或例外
+
+扩展 `SafeHtml` 时，请把范围压到最小，并同时提供：
+
+- 具体是哪一个调用点需要新增能力
+- 最小必要的标签 / 属性列表
+- 恶意 payload 回归测试，以及新允许结构的正向测试
+- PR inventory 里对该例外为何安全的简短说明
+
+## 当前明确不动的范围
+
+这次加固不会修改 `src/components/MarkdownRenderer/*`，因为那部分是维护者最近刚刚加固过的路径。导出工具、编辑器内部 DOM 辅助逻辑会单独审视，只有在信任边界清晰时才继续扩大改造范围。

--- a/docs/en/security-content-rendering.md
+++ b/docs/en/security-content-rendering.md
@@ -1,0 +1,66 @@
+<!--
+Contributor guide for SafeHtml and DOMPurify-backed content rendering.
+-->
+
+# Security Content Rendering
+
+## Why This Exists
+
+`SafeHtml` gives non-Markdown render paths one shared sanitization boundary. Use it whenever frontend code needs to render HTML that is not a hardcoded trusted constant.
+
+This helper wraps `dompurify` and applies a conservative default:
+
+- strips `<script>` and event handler attributes
+- blocks `javascript:` / `vbscript:` URLs
+- blocks `data:` URLs except image MIME types on `src`
+- blocks embedded frames and similar high-risk tags by default
+
+Note: `dompurify` already ships its own TypeScript types, so no extra `@types/dompurify` package is required.
+
+## Profiles
+
+### `strict`
+
+Use for short inline HTML such as slogans, labels, modal copy, or admin-configured snippets that only need emphasis and links.
+
+### `markdown-output`
+
+Use for sanitized rich text that may contain paragraphs, lists, headings, images, tables, or links.
+
+### `svg`
+
+Use only for inline SVG fragments that truly need SVG markup. Keep this profile rare and add focused tests for every new tag or attribute you allow.
+
+## Example
+
+```tsx
+import SafeHtml from '@/components/base/SafeHtml';
+
+<SafeHtml
+  as="div"
+  html={content}
+  profile="markdown-output"
+  allowedTags={['variable']}
+  allowedAttributes={['data-key']}
+/>;
+```
+
+## Choosing A Profile
+
+- Start with `strict`.
+- Move to `markdown-output` only when the source genuinely needs block-level rich text.
+- Use `allowedTags` / `allowedAttributes` only for narrow, documented exceptions.
+- Do not bypass `SafeHtml` for new user-content render paths.
+
+## Requesting A New Profile Or Exception
+
+When extending `SafeHtml`, keep the scope narrow and include:
+
+- the exact call-site that needs the extra markup
+- the minimum new tags or attributes required
+- regression tests for malicious payloads and the new allowed shape
+- a short note in the PR body inventory about why the exception is safe
+
+## Current Non-Goals
+
+This hardening intentionally does not change `src/components/MarkdownRenderer/*`, which maintainers hardened recently. Export utilities and editor-internal DOM helpers should be reviewed separately and only widened when their trust boundary is clear.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "copy-webpack-plugin": "11.0.0",
     "create-puzzle": "^3.0.2",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.4.1",
     "ds-markdown": " 0.1.10-beta.1",
     "ds-markdown-mermaid-plugin": "^0.0.3",
     "globby": "^14.1.0",

--- a/src/components/base/SafeHtml/SafeHtml.tsx
+++ b/src/components/base/SafeHtml/SafeHtml.tsx
@@ -1,0 +1,316 @@
+/**
+ * SafeHtml centralizes user-authored HTML rendering behind DOMPurify so that
+ * non-Markdown render paths share one conservative XSS boundary.
+ *
+ * Threat model:
+ * - blocks script tags, event handler attributes, iframe/object-style embeds
+ * - blocks javascript:/vbscript: URLs
+ * - only allows data: URIs for image sources
+ * - keeps profile-based allowlists narrow so each call-site can opt into just
+ *   the markup shape it needs
+ *
+ * Profile intent:
+ * - strict: inline formatting only
+ * - markdown-output: common rich-text/markdown HTML
+ * - svg: sanitized inline SVG fragments
+ */
+import createDOMPurify, { type Config, type DOMPurify } from 'dompurify';
+import React, { useMemo } from 'react';
+
+export type SafeHtmlProfile = 'strict' | 'markdown-output' | 'svg';
+
+export interface SafeHtmlOptions {
+  html?: string | null;
+  profile?: SafeHtmlProfile;
+  allowedTags?: string[];
+  allowedAttributes?: string[];
+}
+
+export interface SafeHtmlProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'children'>,
+    SafeHtmlOptions {
+  as?: keyof React.JSX.IntrinsicElements;
+}
+
+const SAFE_IMAGE_DATA_URI_RE =
+  /^data:image\/(?:bmp|gif|jpeg|jpg|png|svg\+xml|webp);base64,[a-z0-9+/]+=*$/i;
+const SAFE_URI_BASE = 'https://safe-html.invalid';
+const SAFE_URI_ATTRIBUTES = new Set([
+  'action',
+  'cite',
+  'formaction',
+  'href',
+  'poster',
+  'src',
+  'xlink:href',
+]);
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+const COMMON_FORBID_TAGS = [
+  'audio',
+  'base',
+  'embed',
+  'form',
+  'iframe',
+  'input',
+  'link',
+  'meta',
+  'object',
+  'script',
+  'style',
+  'textarea',
+  'video',
+];
+const COMMON_FORBID_ATTRIBUTES = ['formaction', 'srcset'];
+const COMMON_FORBID_CONTENTS = ['script', 'style', 'iframe', 'object', 'embed'];
+
+const STRICT_ALLOWED_TAGS = [
+  'a',
+  'abbr',
+  'b',
+  'br',
+  'code',
+  'em',
+  'i',
+  'kbd',
+  'mark',
+  's',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'u',
+];
+const STRICT_ALLOWED_ATTRIBUTES = [
+  'aria-hidden',
+  'aria-label',
+  'class',
+  'dir',
+  'href',
+  'lang',
+  'rel',
+  'role',
+  'target',
+  'title',
+];
+const MARKDOWN_ALLOWED_TAGS = [
+  ...STRICT_ALLOWED_TAGS,
+  'blockquote',
+  'del',
+  'div',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'img',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+];
+const MARKDOWN_ALLOWED_ATTRIBUTES = [
+  ...STRICT_ALLOWED_ATTRIBUTES,
+  'alt',
+  'colspan',
+  'height',
+  'scope',
+  'src',
+  'width',
+];
+
+let sanitizerInstance: DOMPurify | null | undefined;
+
+const toUniqueList = (values: string[]) => Array.from(new Set(values));
+
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const isSafeUri = (value: string, attributeName: string) => {
+  const normalized = value.trim().replace(/[\u0000-\u001F\u007F]+/g, '');
+  if (!normalized) {
+    return true;
+  }
+
+  if (
+    normalized.startsWith('#') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('./') ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('?') ||
+    normalized.startsWith('//')
+  ) {
+    return true;
+  }
+
+  if (normalized.toLowerCase().startsWith('data:')) {
+    return attributeName === 'src' && SAFE_IMAGE_DATA_URI_RE.test(normalized);
+  }
+
+  try {
+    const parsed = new URL(normalized, SAFE_URI_BASE);
+    return SAFE_PROTOCOLS.has(parsed.protocol.toLowerCase());
+  } catch {
+    return false;
+  }
+};
+
+const getSanitizer = () => {
+  if (sanitizerInstance !== undefined) {
+    return sanitizerInstance;
+  }
+
+  if (typeof window === 'undefined' || !window.document) {
+    sanitizerInstance = null;
+    return sanitizerInstance;
+  }
+
+  sanitizerInstance = createDOMPurify(window);
+  sanitizerInstance.addHook('afterSanitizeAttributes', (node) => {
+    if (!(node instanceof window.Element)) {
+      return;
+    }
+
+    Array.from(node.attributes).forEach((attribute) => {
+      const attributeName = attribute.name.toLowerCase();
+      if (!SAFE_URI_ATTRIBUTES.has(attributeName)) {
+        return;
+      }
+
+      if (!isSafeUri(attribute.value, attributeName)) {
+        node.removeAttribute(attribute.name);
+      }
+    });
+
+    if (
+      node.nodeName.toLowerCase() === 'a' &&
+      node.getAttribute('target') === '_blank'
+    ) {
+      const relValues = new Set(
+        (node.getAttribute('rel') || '')
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((value) => value.toLowerCase()),
+      );
+      relValues.add('noopener');
+      relValues.add('noreferrer');
+      node.setAttribute('rel', Array.from(relValues).join(' '));
+    }
+  });
+
+  return sanitizerInstance;
+};
+
+const buildConfig = ({
+  profile = 'strict',
+  allowedAttributes = [],
+  allowedTags = [],
+}: Omit<Required<SafeHtmlOptions>, 'html'>): Config => {
+  const sharedConfig: Config = {
+    ADD_FORBID_CONTENTS: COMMON_FORBID_CONTENTS,
+    ALLOW_ARIA_ATTR: true,
+    ALLOW_DATA_ATTR: false,
+    FORCE_BODY: true,
+    FORBID_ATTR: COMMON_FORBID_ATTRIBUTES,
+    SANITIZE_DOM: true,
+    SANITIZE_NAMED_PROPS: true,
+  };
+
+  if (profile === 'svg') {
+    return {
+      ...sharedConfig,
+      ADD_ATTR: toUniqueList(allowedAttributes),
+      ADD_TAGS: toUniqueList(allowedTags),
+      FORBID_TAGS: [
+        ...COMMON_FORBID_TAGS,
+        'animate',
+        'discard',
+        'foreignObject',
+        'set',
+      ],
+      USE_PROFILES: { svg: true, svgFilters: true },
+    };
+  }
+
+  const baseTags =
+    profile === 'markdown-output' ? MARKDOWN_ALLOWED_TAGS : STRICT_ALLOWED_TAGS;
+  const baseAttributes =
+    profile === 'markdown-output'
+      ? MARKDOWN_ALLOWED_ATTRIBUTES
+      : STRICT_ALLOWED_ATTRIBUTES;
+
+  return {
+    ...sharedConfig,
+    ALLOWED_ATTR: toUniqueList([...baseAttributes, ...allowedAttributes]),
+    ALLOWED_TAGS: toUniqueList([...baseTags, ...allowedTags]),
+    FORBID_TAGS: COMMON_FORBID_TAGS,
+  };
+};
+
+export const sanitizeHtml = ({
+  html = '',
+  profile = 'strict',
+  allowedAttributes = [],
+  allowedTags = [],
+}: SafeHtmlOptions): string => {
+  if (!html) {
+    return '';
+  }
+
+  const sanitizer = getSanitizer();
+  if (!sanitizer || !sanitizer.isSupported) {
+    return escapeHtml(html);
+  }
+
+  return String(
+    sanitizer.sanitize(
+      html,
+      buildConfig({
+        allowedAttributes,
+        allowedTags,
+        profile,
+      }),
+    ),
+  );
+};
+
+const SafeHtml: React.FC<SafeHtmlProps> = ({
+  allowedAttributes,
+  allowedTags,
+  as = 'div',
+  html,
+  profile = 'strict',
+  ...restProps
+}) => {
+  const sanitizedHtml = useMemo(
+    () =>
+      sanitizeHtml({
+        allowedAttributes,
+        allowedTags,
+        html,
+        profile,
+      }),
+    [allowedAttributes, allowedTags, html, profile],
+  );
+
+  return React.createElement(as, {
+    ...restProps,
+    dangerouslySetInnerHTML: { __html: sanitizedHtml },
+  });
+};
+
+export default SafeHtml;

--- a/src/components/base/SafeHtml/index.ts
+++ b/src/components/base/SafeHtml/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-export the shared SafeHtml renderer and helper types for direct imports.
+ */
+export { default, sanitizeHtml } from './SafeHtml';
+export type {
+  SafeHtmlOptions,
+  SafeHtmlProfile,
+  SafeHtmlProps,
+} from './SafeHtml';

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -11,6 +11,12 @@ export { default as HoverScrollbar } from './HoverScrollbar';
 export { default as McpInstallType } from './McpInstallType';
 export { default as McpStatus } from './McpStatus';
 export { default as MenuListItem } from './MenuListItem';
+export { default as SafeHtml, sanitizeHtml } from './SafeHtml';
+export type {
+  SafeHtmlOptions,
+  SafeHtmlProfile,
+  SafeHtmlProps,
+} from './SafeHtml';
 export { default as SecondMenuItem } from './SecondMenuItem';
 export { default as SvgIcon } from './SvgIcon';
 export { default as SvgIconGoodTheme } from './SvgIconGoodTheme';

--- a/src/examples/TiptapVariableInputTest/index.tsx
+++ b/src/examples/TiptapVariableInputTest/index.tsx
@@ -3,6 +3,7 @@
  * Tiptap 变量输入组件测试示例
  */
 
+import SafeHtml from '@/components/base/SafeHtml';
 import {
   CodeOutlined,
   EyeOutlined,
@@ -34,6 +35,15 @@ import { VariableType } from '../../components/TiptapVariableInput/types';
 
 const { Title, Paragraph, Text } = Typography;
 const { Panel } = Collapse;
+const SAFE_HTML_VARIABLE_ATTRIBUTES = [
+  'data-id',
+  'data-is-tool',
+  'data-key',
+  'data-label',
+  'data-name',
+  'data-type',
+  'data-type-id',
+];
 
 const TiptapVariableInputTestExample: React.FC = () => {
   // 基础状态
@@ -615,7 +625,12 @@ const TiptapVariableInputTestExample: React.FC = () => {
 
                 <div>
                   <Text strong>渲染预览：</Text>
-                  <div
+                  <SafeHtml
+                    as="div"
+                    allowedAttributes={SAFE_HTML_VARIABLE_ATTRIBUTES}
+                    allowedTags={['variable']}
+                    html={promptValue}
+                    profile="markdown-output"
                     style={{
                       background: '#f5f5f5',
                       padding: '10px',
@@ -624,7 +639,6 @@ const TiptapVariableInputTestExample: React.FC = () => {
                       minHeight: '50px',
                       border: '1px solid #d9d9d9',
                     }}
-                    dangerouslySetInnerHTML={{ __html: promptValue }}
                   />
                 </div>
 

--- a/src/hooks/useDrawerScroll.ts
+++ b/src/hooks/useDrawerScroll.ts
@@ -15,7 +15,7 @@ const useDrawerScroll = (visible: boolean): void => {
     // 创建新的样式元素
     const style = document.createElement('style');
     style.id = 'drawer-scroll-style';
-    style.innerHTML = `
+    style.textContent = `
         .${className} {
           overflow-x: hidden !important;
         }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
 import ChatInputHome from '@/components/ChatInputHome';
+import SafeHtml from '@/components/base/SafeHtml';
 import Loading from '@/components/custom/Loading';
 import useConversation from '@/hooks/useConversation';
 import useSelectedComponent from '@/hooks/useSelectedComponent';
@@ -244,9 +245,11 @@ const Home: React.FC = () => {
     <div className={cx(styles.container, 'flex', 'flex-col', 'items-center')}>
       {/* 输入框区域 */}
       <div className={cx(styles.inputSection)}>
-        <h2
+        <SafeHtml
+          as="h2"
           className={cx(styles.title)}
-          dangerouslySetInnerHTML={{ __html: tenantConfigInfo?.homeSlogan }}
+          html={tenantConfigInfo?.homeSlogan}
+          profile="markdown-output"
         />
         {/*<div className={cx(styles.title)}>
           <PureMarkdownRenderer

--- a/src/pages/Login/BasicLayout/index.tsx
+++ b/src/pages/Login/BasicLayout/index.tsx
@@ -1,3 +1,4 @@
+import SafeHtml from '@/components/base/SafeHtml';
 import ConditionRender from '@/components/ConditionRender';
 import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';
@@ -29,17 +30,17 @@ const BasicLayout: React.FC<PropsWithChildren> = ({ children }) => {
           {/*  知识库与数据表存储能力，MCP接入以及开放能力*/}
           {/*</p>*/}
 
-          <p
+          <SafeHtml
+            as="p"
             className={cx(styles.title, 'text-ellipsis-2')}
-            dangerouslySetInnerHTML={{
-              __html: tenantConfigInfo?.loginPageText,
-            }}
+            html={tenantConfigInfo?.loginPageText}
+            profile="markdown-output"
           />
-          <p
+          <SafeHtml
+            as="p"
             className={cx(styles['sub-title'], 'text-ellipsis-2')}
-            dangerouslySetInnerHTML={{
-              __html: tenantConfigInfo?.loginPageSubText,
-            }}
+            html={tenantConfigInfo?.loginPageSubText}
+            profile="markdown-output"
           />
         </div>
       </div>

--- a/src/pages/SpaceLog/LogDetails/index.tsx
+++ b/src/pages/SpaceLog/LogDetails/index.tsx
@@ -197,11 +197,6 @@ const LogDetails: React.FC<LogDetailsProps> = ({
               {dict('PC.Pages.SpaceLog.LogDetails.output')}
             </h5>
             <pre>{outputData}</pre>
-            {/* <pre
-              dangerouslySetInnerHTML={{
-                __html: md.render(outputData),
-              }}
-            /> */}
           </div>
         </>
       ) : (

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -1,3 +1,4 @@
+import SafeHtml from '@/components/base/SafeHtml';
 import {
   AGENT_NOT_EXIST,
   AGENT_SERVICE_RUNNING,
@@ -169,8 +170,10 @@ const errorHandler = (error: any, opts: any) => {
           // Modal 类型的错误提示通常需要显示，但也可以加入去重逻辑
           if (shouldShowErrorMessage(errorMessage)) {
             Modal.warning({
-              content: React.createElement('div', {
-                dangerouslySetInnerHTML: { __html: errorMessage },
+              content: React.createElement(SafeHtml, {
+                as: 'div',
+                html: errorMessage,
+                profile: 'markdown-output',
               }),
             });
           }

--- a/src/utils/pptxFallbackRenderer.ts
+++ b/src/utils/pptxFallbackRenderer.ts
@@ -59,7 +59,7 @@ export function renderFallback(
 ) {
   if (!container) return;
 
-  container.innerHTML = '';
+  container.replaceChildren();
 
   // 创建主容器
   const wrapper = document.createElement('div');
@@ -136,7 +136,15 @@ export function renderFallback(
   `;
 
   const notice = document.createElement('div');
-  notice.innerHTML = dict('PC.Utils.PptxFallbackRenderer.complexFormatNotice');
+  const noticeLines = dict(
+    'PC.Utils.PptxFallbackRenderer.complexFormatNotice',
+  ).split(/<br\s*\/?>/i);
+  noticeLines.forEach((line, index) => {
+    if (index > 0) {
+      notice.appendChild(document.createElement('br'));
+    }
+    notice.appendChild(document.createTextNode(line));
+  });
   notice.style.cssText = `
     color: #8c8c8c;
     font-size: 12px;

--- a/tests/components/SafeHtml.test.tsx
+++ b/tests/components/SafeHtml.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for the shared SafeHtml sanitizer and wrapper component.
+ */
+import SafeHtml, { sanitizeHtml } from '@/components/base/SafeHtml';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+const parseSanitizedHtml = (html: string) => {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container;
+};
+
+describe('SafeHtml', () => {
+  test('strips script tags and script content', () => {
+    const sanitized = sanitizeHtml({
+      html: '<strong>safe</strong><script>alert("xss")</script>',
+    });
+    const container = parseSanitizedHtml(sanitized);
+
+    expect(container.querySelector('strong')).toHaveTextContent('safe');
+    expect(container.querySelector('script')).toBeNull();
+    expect(sanitized).not.toContain('alert("xss")');
+  });
+
+  test('strips inline event handlers from allowed tags', () => {
+    const sanitized = sanitizeHtml({
+      html: '<img src="/ok.png" onerror="alert(1)" /><span onclick="x()">Tap</span>',
+      profile: 'markdown-output',
+    });
+    const container = parseSanitizedHtml(sanitized);
+    const image = container.querySelector('img');
+    const span = container.querySelector('span');
+
+    expect(image).toHaveAttribute('src', '/ok.png');
+    expect(image).not.toHaveAttribute('onerror');
+    expect(span).toHaveTextContent('Tap');
+    expect(span).not.toHaveAttribute('onclick');
+  });
+
+  test('strips javascript and vbscript URI payloads', () => {
+    const sanitized = sanitizeHtml({
+      html: '<a href="javascript:alert(1)">Open</a><img src="vbscript:msgbox(1)" alt="bad" />',
+      profile: 'markdown-output',
+    });
+    const container = parseSanitizedHtml(sanitized);
+    const link = container.querySelector('a');
+    const image = container.querySelector('img');
+
+    expect(link).toHaveTextContent('Open');
+    expect(link).not.toHaveAttribute('href');
+    expect(image).toHaveAttribute('alt', 'bad');
+    expect(image).not.toHaveAttribute('src');
+  });
+
+  test('allows image data URIs but blocks other data URIs', () => {
+    const sanitized = sanitizeHtml({
+      html: '<img src="data:image/png;base64,AAAA" alt="preview" /><a href="data:text/html;base64,AAAA">bad</a>',
+      profile: 'markdown-output',
+    });
+    const container = parseSanitizedHtml(sanitized);
+    const image = container.querySelector('img');
+    const link = container.querySelector('a');
+
+    expect(image).toHaveAttribute('src', 'data:image/png;base64,AAAA');
+    expect(link).toHaveTextContent('bad');
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  test('preserves benign markdown HTML and hardens target blank links', () => {
+    const sanitized = sanitizeHtml({
+      html: '<p><a href="https://example.com" target="_blank">Docs</a></p><ul><li>Item</li></ul>',
+      profile: 'markdown-output',
+    });
+    const container = parseSanitizedHtml(sanitized);
+    const link = container.querySelector('a');
+
+    expect(container.querySelector('p')).toBeTruthy();
+    expect(container.querySelector('ul li')).toHaveTextContent('Item');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('round trips plaintext untouched', () => {
+    expect(sanitizeHtml({ html: 'Plain text only' })).toBe('Plain text only');
+  });
+
+  test('supports explicitly allowed custom tags and attributes', () => {
+    const sanitized = sanitizeHtml({
+      html: '<variable data-key="user.name">user.name</variable>',
+      profile: 'markdown-output',
+      allowedAttributes: ['data-key'],
+      allowedTags: ['variable'],
+    });
+    const container = parseSanitizedHtml(sanitized);
+    const variable = container.querySelector('variable');
+
+    expect(variable).toHaveTextContent('user.name');
+    expect(variable).toHaveAttribute('data-key', 'user.name');
+  });
+
+  test('renders the requested wrapper element', () => {
+    render(
+      <SafeHtml
+        as="p"
+        data-testid="safe-html"
+        html="Hello <strong>team</strong>"
+      />,
+    );
+
+    const wrapper = screen.getByTestId('safe-html');
+    expect(wrapper.tagName).toBe('P');
+    expect(wrapper).toContainHTML('Hello <strong>team</strong>');
+  });
+});


### PR DESCRIPTION
## English

### Summary
This PR adds a shared `SafeHtml` boundary backed by `dompurify` and migrates non-Markdown user-content HTML render paths onto it.

This PR does **not** change `src/components/MarkdownRenderer/*`, which maintainers hardened recently. It hardens other render paths and reduces the chance of future regressions.

### Motivation
I have not observed a live exploit or production incident caused by these `dangerouslySetInnerHTML` call sites. This came from a code audit: I noticed several non-Markdown HTML render paths that still rendered configurable or API-provided content directly. The goal is preventive hardening and a shared safety boundary, not a claim that the current code has already been exploited.

### What Changed
- Added `src/components/base/SafeHtml/SafeHtml.tsx` with three profiles: `strict`, `markdown-output`, and `svg`.
- Added URI hardening for `javascript:` / `vbscript:` payloads, image-only `data:` URIs, and `target="_blank"` link rel normalization.
- Refactored these non-recent-window render paths to use `SafeHtml`:
  - `src/pages/Home/index.tsx`
  - `src/pages/Login/BasicLayout/index.tsx`
  - `src/services/common.ts`
  - `src/examples/TiptapVariableInputTest/index.tsx`
- Added regression tests in `tests/components/SafeHtml.test.tsx`.
- Added contributor docs in `docs/en/security-content-rendering.md` and `docs/ch/security-content-rendering.md`.
- Reduced a few low-risk inventory hits by replacing style/text fallback `innerHTML` usage in utility code.

### Inventory / Evidence
| Check | Before (`origin/dev`) | After (this branch) |
| --- | --- | --- |
| `dangerouslySetInnerHTML` runtime sinks outside the recent maintainer exclusion window | 5 | 0 |
| Remaining repo `dangerouslySetInnerHTML` sinks | `XProTable`, `SiteFooter`, plus comments/helpers | `XProTable`, `SiteFooter`, plus the internal `SafeHtml` wrapper/helper mentions |
| `innerHTML =` utility hits | 13 | 10 |
| `document.write` utility hits | 1 | 1 |

Remaining exclusions are intentional:
- `src/components/MarkdownRenderer/*` is explicitly out of scope because maintainers hardened it recently.
- `src/components/ProComponents/XProTable/index.tsx` is a trusted-constant style injection in a recent maintainer-touched file.
- `src/components/SiteFooter/index.tsx` is a recent maintainer-touched file.
- `src/components/business-component/FilePreview/index.tsx` and `src/components/ChatInputHome/MentionEditor/index.tsx` remain out of scope because they were touched recently and are editor/preview-heavy paths.
- `src/utils/markdownToPdf.ts` remains a utility follow-up item; this PR leaves its `document.write` preview path unchanged.

### Dependency Note
- Added `dompurify` `3.4.1` (license: `MPL-2.0 OR Apache-2.0`).
- Did **not** add `@types/dompurify` because `dompurify` already ships its own types and the DefinitelyTyped package is deprecated stub-only.

### Validation
- ✅ `pnpm exec prettier --check <changed files>`
- ✅ `pnpm exec max lint`
- ✅ `node scripts/check-hardcoded-i18n.js`
- ✅ `pnpm build:dev`
- ⚠️ `pnpm exec tsc --noEmit` is blocked by an existing repo dependency issue: `TS2688 Cannot find type definition file for 'testing-library__jest-dom'`.
- ⚠️ `pnpm exec vitest tests/components/SafeHtml.test.tsx --run` is blocked by the repo's existing Vitest/Vite startup mismatch: `vite` does not export `./module-runner` for the current combination.

### Non-Goals
- No MarkdownRenderer behavior changes.
- No FilePreview / MentionEditor / Monaco / DesktopPreview changes.
- No build-config changes.

---

## 中文

### 摘要
这个 PR 新增了一个基于 `dompurify` 的共享 `SafeHtml` 安全边界，并把非 Markdown 的用户内容 HTML 渲染入口统一收口到这里。

这个 PR **不会**修改 `src/components/MarkdownRenderer/*`；那部分是维护者最近刚加固过的路径。本次工作聚焦于其余渲染入口，减少后续回归风险。

### 背景
我这边没有直接遇到已经被利用的线上注入安全事件。这个 PR 是在代码审计时注意到仍有几处非 Markdown 的 HTML 渲染路径直接渲染可配置内容或接口返回内容，所以做一个预防性的安全收口。这里的定位是降低后续回归风险，并不是声称当前代码已经发生过实际攻击。

### 变更内容
- 新增 `src/components/base/SafeHtml/SafeHtml.tsx`，支持 `strict`、`markdown-output`、`svg` 三种 profile。
- 增加 URI 安全收口：拦截 `javascript:` / `vbscript:`，只允许图片 `data:` URI，并为 `target="_blank"` 自动补齐安全 `rel`。
- 将以下不在最近维护者改动窗口内的渲染入口切到 `SafeHtml`：
  - `src/pages/Home/index.tsx`
  - `src/pages/Login/BasicLayout/index.tsx`
  - `src/services/common.ts`
  - `src/examples/TiptapVariableInputTest/index.tsx`
- 新增回归测试 `tests/components/SafeHtml.test.tsx`。
- 新增中英文贡献文档：`docs/en/security-content-rendering.md`、`docs/ch/security-content-rendering.md`。
- 顺手清掉了几处低风险的 inventory 命中，把工具代码里的部分 `innerHTML` 用法替换成更窄的实现。

### Inventory / 证据
| 检查项 | 修改前（`origin/dev`） | 修改后（当前分支） |
| --- | --- | --- |
| 最近维护者排除窗口之外的 `dangerouslySetInnerHTML` 运行时渲染入口 | 5 | 0 |
| 仓库内剩余 `dangerouslySetInnerHTML` 命中 | `XProTable`、`SiteFooter`，以及注释/辅助逻辑 | `XProTable`、`SiteFooter`，以及 `SafeHtml` 内部封装/辅助逻辑 |
| `innerHTML =` 工具类命中 | 13 | 10 |
| `document.write` 工具类命中 | 1 | 1 |

剩余排除项都是刻意保留：
- `src/components/MarkdownRenderer/*` 明确不动，因为维护者最近刚加固过。
- `src/components/ProComponents/XProTable/index.tsx` 属于最近维护者改动文件中的可信常量样式注入。
- `src/components/SiteFooter/index.tsx` 属于最近维护者改动文件。
- `src/components/business-component/FilePreview/index.tsx` 和 `src/components/ChatInputHome/MentionEditor/index.tsx` 最近动过，而且属于编辑器/预览重路径，这次不扩散进去。
- `src/utils/markdownToPdf.ts` 仍作为后续 utility 跟进项，本 PR 不改它的 `document.write` 预览路径。

### 依赖说明
- 新增 `dompurify` `3.4.1`，许可证为 `MPL-2.0 OR Apache-2.0`。
- 没有新增 `@types/dompurify`，因为 `dompurify` 已自带类型，而 DefinitelyTyped 的对应包已经是废弃 stub。

### 验证
- ✅ `pnpm exec prettier --check <changed files>`
- ✅ `pnpm exec max lint`
- ✅ `node scripts/check-hardcoded-i18n.js`
- ✅ `pnpm build:dev`
- ⚠️ `pnpm exec tsc --noEmit` 被仓库现有依赖问题阻塞：`TS2688 Cannot find type definition file for 'testing-library__jest-dom'`
- ⚠️ `pnpm exec vitest tests/components/SafeHtml.test.tsx --run` 被仓库现有 Vitest/Vite 启动问题阻塞：当前组合下 `vite` 没有导出 `./module-runner`

### 非目标
- 不修改 MarkdownRenderer 行为
- 不碰 FilePreview / MentionEditor / Monaco / DesktopPreview
- 不改构建配置
