### PR TITLE
优化资源定价价格精度为小数点后四位数

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuwax-frontend",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": false,
   "homepage": "https://nuwax.com",
   "bugs": {

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -2,5 +2,5 @@
  * 应用版本信息
  * 此文件由 scripts/generate-version.js 自动生成，请勿手动修改
  */
-export const APP_VERSION = '1.1.11';
+export const APP_VERSION = '1.1.12';
 export const APP_NAME = 'nuwax-frontend';

--- a/src/pages/GlobalModelManage/Pricing/ModelPricingModal/index.tsx
+++ b/src/pages/GlobalModelManage/Pricing/ModelPricingModal/index.tsx
@@ -3,6 +3,7 @@ import type { ResourcePricingConfigInfo } from '@/pages/SpaceResource/types/reso
 import { dict } from '@/services/i18nRuntime';
 import { apiSystemModelList } from '@/services/systemManage';
 import { customizeRequiredMark } from '@/utils/form';
+import { createPriceInputNumberProps } from '@/utils/priceInput';
 import type { FormInstance } from 'antd';
 import { Button, Form, Input, InputNumber, Select, message } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -12,6 +13,9 @@ import {
   apiSystemUpdateModelPricing,
 } from '../services/resource';
 import styles from './index.less';
+
+/** 模型定价价格输入框共用配置（最多 4 位小数）。 */
+const priceInputProps = createPriceInputNumberProps();
 
 interface ModelOption {
   id: number;
@@ -362,12 +366,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.inputPriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.inputPrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.inputPrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'inputPrice', v || 0)}
                 />
@@ -377,12 +378,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.outputPriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.outputPrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.outputPrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'outputPrice', v || 0)}
                 />
@@ -392,12 +390,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.cachePriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.cachePrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.cachePrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'cachePrice', v || 0)}
                 />

--- a/src/pages/SpaceResource/Pricing/ModelPricingTab/ModelPricingModal/index.tsx
+++ b/src/pages/SpaceResource/Pricing/ModelPricingTab/ModelPricingModal/index.tsx
@@ -95,6 +95,7 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
     if (!open || isEdit) {
       return;
     }
+    // 排除已配置定价的模型
     const excludedIds = new Set(existingModelIds);
 
     /** 仅在新增模式下加载可选模型，并排除已配置定价的模型。 */

--- a/src/pages/SpaceResource/Pricing/ModelPricingTab/ModelPricingModal/index.tsx
+++ b/src/pages/SpaceResource/Pricing/ModelPricingTab/ModelPricingModal/index.tsx
@@ -2,6 +2,7 @@ import CustomFormModal from '@/components/CustomFormModal';
 import { dict } from '@/services/i18nRuntime';
 import { apiModelListSpace } from '@/services/modelConfig';
 import { customizeRequiredMark } from '@/utils/form';
+import { createPriceInputNumberProps } from '@/utils/priceInput';
 import type { FormInstance } from 'antd';
 import { Button, Form, Input, InputNumber, Select, message } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -12,6 +13,9 @@ import {
 } from '../../../services/resource';
 import type { ResourcePricingConfigInfo } from '../../../types/resource';
 import styles from './index.less';
+
+/** 模型定价价格输入框共用配置（最多 4 位小数）。 */
+const priceInputProps = createPriceInputNumberProps();
 
 interface ModelOption {
   id: number;
@@ -363,12 +367,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.inputPriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.inputPrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.inputPrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'inputPrice', v || 0)}
                 />
@@ -378,12 +379,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.outputPriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.outputPrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.outputPrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'outputPrice', v || 0)}
                 />
@@ -393,12 +391,9 @@ const ModelPricingModal: React.FC<ModelPricingModalProps> = ({
                   {dict('PC.Pages.SpaceResourcePricing.cachePriceLabel')}
                 </span>
                 <InputNumber
-                  value={tier.cachePrice}
-                  min={0}
-                  max={100000000}
-                  step={0.01}
-                  precision={2}
+                  {...priceInputProps}
                   size="small"
+                  value={tier.cachePrice}
                   className={styles['model-price-input']}
                   onChange={(v) => updateTier(index, 'cachePrice', v || 0)}
                 />

--- a/src/pages/SpaceResource/Pricing/SkillPricingTab/SkillPricingFormModal/index.tsx
+++ b/src/pages/SpaceResource/Pricing/SkillPricingTab/SkillPricingFormModal/index.tsx
@@ -12,6 +12,7 @@ import { AgentComponentTypeEnum } from '@/types/enums/agent';
 import type { AgentAddComponentStatusInfo } from '@/types/interfaces/agentConfig';
 import type { CreatedNodeItem } from '@/types/interfaces/common';
 import { customizeRequiredMark } from '@/utils/form';
+import { createPriceInputNumberProps } from '@/utils/priceInput';
 import { Form, Input, InputNumber, Radio, Switch, message } from 'antd';
 import React, { useEffect, useState } from 'react';
 import styles from './index.less';
@@ -25,6 +26,9 @@ interface SkillPricingFormModalProps {
   onCancel: () => void;
   onSaved: () => void;
 }
+
+/** 技能定价价格输入框共用配置（最多 4 位小数）。 */
+const priceInputProps = createPriceInputNumberProps();
 
 // 技能定价模式选项
 const SKILL_PRICING_MODE_OPTIONS = [
@@ -216,10 +220,7 @@ const SkillPricingFormModal: React.FC<SkillPricingFormModalProps> = ({
             rules={[{ required: true }]}
           >
             <InputNumber
-              min={0}
-              max={100000000}
-              step={0.01}
-              precision={2}
+              {...priceInputProps}
               className="w-full"
               prefix="¥"
               placeholder={dict(

--- a/src/pages/SpaceResource/Pricing/ToolPricingTab/ToolPricingFormModal/index.tsx
+++ b/src/pages/SpaceResource/Pricing/ToolPricingTab/ToolPricingFormModal/index.tsx
@@ -5,6 +5,7 @@ import { AgentComponentTypeEnum } from '@/types/enums/agent';
 import type { AgentAddComponentStatusInfo } from '@/types/interfaces/agentConfig';
 import type { CreatedNodeItem } from '@/types/interfaces/common';
 import { customizeRequiredMark } from '@/utils/form';
+import { createPriceInputNumberProps } from '@/utils/priceInput';
 import { TOOL_PRICING_TYPE_OPTIONS } from '@/utils/resourcePricing';
 import { Form, Input, InputNumber, Select, Switch, message } from 'antd';
 import React, { useEffect, useState } from 'react';
@@ -18,6 +19,9 @@ import {
   ToolPricingTargetType,
 } from '../../../types/resource';
 import styles from './index.less';
+
+/** 插件定价价格输入框共用配置（最多 4 位小数）。 */
+const priceInputProps = createPriceInputNumberProps({ decimals: 4 });
 
 /** 表单弹窗 z-index（嵌套的 Created 需高于此值，否则列表弹层会被压住） */
 const TOOL_PRICING_FORM_MODAL_Z = 1000;
@@ -220,13 +224,7 @@ const ToolPricingFormModal: React.FC<ToolPricingFormModalProps> = ({
               label={dict('PC.Pages.SpaceResourcePricing.price')}
               rules={[{ required: true }]}
             >
-              <InputNumber
-                min={0}
-                precision={2}
-                step={0.01}
-                max={100000000}
-                className="w-full"
-              />
+              <InputNumber {...priceInputProps} className="w-full" />
             </Form.Item>
             <Form.Item
               name="pricingType"

--- a/src/utils/priceInput.ts
+++ b/src/utils/priceInput.ts
@@ -1,0 +1,73 @@
+import type { InputNumberProps } from 'antd';
+
+/** 定价输入框默认最多小数位数。 */
+export const DEFAULT_PRICE_INPUT_DECIMALS = 4;
+
+type PriceInputFormatInfo = Parameters<
+  NonNullable<InputNumberProps['formatter']>
+>[1];
+
+/**
+ * 定价输入框展示：按指定小数位截断，并去掉末尾无意义的 0（如 0.99 而非 0.9900）。
+ */
+export const formatPriceInput = (
+  value: number | string | undefined | null,
+  info?: PriceInputFormatInfo,
+  decimals: number = DEFAULT_PRICE_INPUT_DECIMALS,
+): string => {
+  if (info?.userTyping) {
+    return info.input;
+  }
+  if (value === undefined || value === null || value === '') {
+    return '';
+  }
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return '';
+  }
+  return num.toFixed(decimals).replace(/\.?0+$/, '');
+};
+
+/** 定价输入框解析：限制最多指定位数的小数。 */
+export const parsePriceInput = (
+  value: string | undefined,
+  decimals: number = DEFAULT_PRICE_INPUT_DECIMALS,
+): number => {
+  if (!value) {
+    return 0;
+  }
+  const num = Number(value.replace(/[^\d.-]/g, ''));
+  if (!Number.isFinite(num)) {
+    return 0;
+  }
+  const factor = 10 ** decimals;
+  return Math.round(num * factor) / factor;
+};
+
+export interface PriceInputNumberOptions {
+  /** 最多小数位数，默认 4 */
+  decimals?: number;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * 生成定价 InputNumber 共用配置（formatter / parser / step 等）。
+ */
+export const createPriceInputNumberProps = (
+  options: PriceInputNumberOptions = {},
+): Pick<InputNumberProps, 'min' | 'max' | 'step' | 'formatter' | 'parser'> => {
+  const {
+    decimals = DEFAULT_PRICE_INPUT_DECIMALS,
+    min = 0,
+    max = 100000000,
+  } = options;
+
+  return {
+    min,
+    max,
+    step: 10 ** -decimals,
+    formatter: (value, info) => formatPriceInput(value, info, decimals),
+    parser: (value) => parsePriceInput(value, decimals),
+  };
+};


### PR DESCRIPTION
资源定价页下模型定价、插件、工作流和技能定价精度改为小数点后四位数